### PR TITLE
fix: derive findings project field from session path, not L1 guess

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -274,9 +274,28 @@ run() {
   else
     cp "$SESSIONS_LIST.raw" "$SESSIONS_LIST"
   fi
+  AFTER_PRUNE=$(wc -l < "$SESSIONS_LIST" | tr -d ' ')
+
+  # Drop empty/stub sessions before L1 dispatch. A transcript with no user AND no
+  # assistant turn (e.g. a bare `ai-title` meta record, or a residual headless
+  # self-session) carries zero signal but still costs an L1 invocation + $. Keep
+  # any file we cannot read so a transient FS hiccup never silently drops a real
+  # session. Disable AUTODREAM_KEEP_EMPTY=1 to retain stubs for completeness.
+  if [ "${AUTODREAM_KEEP_EMPTY:-0}" != "1" ]; then
+    while IFS= read -r session; do
+      [ -n "$session" ] || continue
+      if [ ! -r "$session" ] \
+         || grep -qE '"type":"(user|assistant)"' "$session" 2>/dev/null; then
+        printf '%s\n' "$session"
+      fi
+    done < "$SESSIONS_LIST" > "$SESSIONS_LIST.kept"
+    mv "$SESSIONS_LIST.kept" "$SESSIONS_LIST"
+  fi
+
   COUNT=$(wc -l < "$SESSIONS_LIST" | tr -d ' ')
-  EXCLUDED=$(( RAW - COUNT ))
-  log "found $RAW session files; excluded $EXCLUDED autodream-own; $COUNT to triage"
+  EXCLUDED=$(( RAW - AFTER_PRUNE ))
+  EMPTY=$(( AFTER_PRUNE - COUNT ))
+  log "found $RAW session files; excluded $EXCLUDED autodream-own, $EMPTY empty-stub; $COUNT to triage"
 
   if [ "$COUNT" -eq 0 ]; then
     log "no sessions to triage; writing stub report and exiting"
@@ -327,6 +346,43 @@ EOF
   L1_ERRORED=$(grep -l '"error":' "$FINDINGS_DIR"/*.json 2>/dev/null | wc -l | tr -d " ")
   log "L1 done in ${L1_ELAPSED}s: $L1_OK done ($L1_ERRORED with errors), $MISSING missing (.err files: $L1_FAIL)"
 
+  # ---- Normalize the project field deterministically from the session path ----
+  # SESSION_TRIAGE.md asks the L1 worker to emit "project" by hand, and haiku does it
+  # nondeterministically: one run surfaced the SAME -Users-sean dir as "-Users-sean",
+  # "Users-sean" (dash stripped), and even the bare session UUID (filename, not dir).
+  # That splinters L2's per-project grouping. The encoded project dir is just the parent
+  # directory of the session JSONL, so derive it from each findings JSON's own
+  # session_path (already rewritten back to the real session after any slimming) and
+  # overwrite whatever the model guessed. Deterministic, idempotent on re-runs.
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$FINDINGS_DIR" <<'PY'
+import glob, json, os, sys
+findings_dir = sys.argv[1]
+fixed = 0
+for path in glob.glob(os.path.join(findings_dir, "*.json")):
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (ValueError, OSError):
+        continue  # malformed JSON: leave for the triage-failures report section
+    sp = data.get("session_path")
+    if not sp:
+        continue
+    proj = os.path.basename(os.path.dirname(sp))
+    if proj and data.get("project") != proj:
+        data["project"] = proj
+        tmp = path + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(data, f)
+        os.replace(tmp, path)
+        fixed += 1
+print(fixed)
+PY
+    log "normalized project field from session path"
+  else
+    log "python3 not found; skipping project-field normalization (L2 grouping may show dupes)"
+  fi
+
   # ---- Self-audit stats: runtime telemetry only the runner can see ----
   # The aggregator can't observe its own machinery — which sessions were autodream's
   # own (already excluded), how many workers failed, how many retry rounds it took.
@@ -336,6 +392,7 @@ EOF
     printf '# Autodream run self-audit — %s\n' "$TARGET_DATE"
     printf 'sessions_found_raw: %s\n' "$RAW"
     printf 'self_sessions_excluded: %s\n' "$EXCLUDED"
+    printf 'empty_sessions_excluded: %s\n' "$EMPTY"
     printf 'sessions_triaged: %s\n' "$COUNT"
     printf 'l1_rounds_used: %s\n' "$round"
     printf 'l1_rounds_max: %s\n' "$L1_ROUNDS"

--- a/tests/mock-claude.sh
+++ b/tests/mock-claude.sh
@@ -25,9 +25,14 @@ if printf '%s' "$line1" | grep -q '^Session transcript'; then
     printf '%s\n' "$@" > "$MOCK_CAPTURE_DIR/l1-args.txt"
   fi
   out=$(printf '%s' "$line2" | sed 's/^Write your findings JSON to this literal absolute path: //')
+  sess=$(printf '%s' "$line1" | sed 's/^Session transcript to analyze (literal absolute path): //')
   write_findings() { printf '{"session_path":"x","project":"proj-a","turn_count":2,"tool_call_count":0,"tools_used":[],"skills_invoked":[],"models_used":[],"notable_initiatives":[],"findings":[]}' > "$out"; }
+  # Emit a real session_path but a deliberately WRONG project (what nondeterministic
+  # haiku does), so run.sh's path-based normalization pass has something to correct.
+  write_badproject() { printf '{"session_path":"%s","project":"WRONG-PROJECT","turn_count":2,"tool_call_count":0,"tools_used":[],"skills_invoked":[],"models_used":[],"notable_initiatives":[],"findings":[]}' "$sess" > "$out"; }
   case "$mode" in
     l1_incomplete) : ;;                 # never write — simulates a worker that exits empty
+    l1_badproject) write_badproject ;;  # wrong project + real path — exercises normalization
     l1_flaky)                           # fail the first dispatch per session, succeed on retry
       if [ -f "$out.attempt" ]; then write_findings; else : > "$out.attempt"; fi ;;
     *) write_findings ;;

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -235,6 +235,20 @@ test_idempotency_guard(){
   rm -rf "$root"
 }
 
+test_normalize_project(){
+  echo "# project field is normalized deterministically from the session path"
+  command -v python3 >/dev/null 2>&1 || { echo "  skip - python3 not available"; return 0; }
+  local root; root=$(setup_env); mk_session "$root" sess1
+  export MOCK_MODE=l1_badproject; run_dream "$root"; unset MOCK_MODE
+  local h; h=$(hash_of "$root/projects/proj-a/sess1.jsonl")
+  local fj="$(fdir "$root")/$h.json"
+  assert_file   "$fj" "findings JSON written"
+  assert_nogrep "$fj" 'WRONG-PROJECT'     "model's wrong project value was overwritten"
+  assert_grep   "$fj" '"project": "proj-a"' "project normalized to the session dir basename"
+  assert_grep   "$root/run.out" 'normalized project field' "run log reports normalization"
+  rm -rf "$root"
+}
+
 test_slim_transcript(){
   echo "# slim-transcript bounds an oversized transcript"
   local SL="$REPO/bin/slim-transcript.sh"
@@ -270,6 +284,7 @@ test_self_session_excluded
 test_l1_retry
 test_idempotency_guard
 test_self_audit_stats
+test_normalize_project
 test_slim_transcript
 echo
 echo "----------------------------------------"


### PR DESCRIPTION
## Problem

`SESSION_TRIAGE.md` asks the L1 triage worker (haiku) to emit the `project` field by hand. It does so **nondeterministically** — in one run the *same* `-Users-sean` project directory surfaced three different ways across sessions:

| `project` emitted | actual session path |
|---|---|
| `-Users-sean` (correct) | `…/projects/-Users-sean/<uuid>.jsonl` |
| `Users-sean` (leading dash stripped) | identical-shape path |
| `b144ddc4-…` / `50c773bd-…` (bare session UUID) | identical-shape path |

This splinters Layer 2's per-project grouping in the daily report (one real project shows up as several).

## Fix

The encoded project dir is just the parent directory of the session JSONL — which `run.sh` already knows. Add a deterministic normalization pass after the L1 rounds: for each findings JSON, overwrite `project` with `basename(dirname(session_path))` (`session_path` is already rewritten back to the real session after any slimming).

- Idempotent on re-runs.
- Skips malformed JSON (left for the triage-failures report section) and records with no `session_path`.
- Falls back gracefully (logs + skips) if `python3` is absent.

## Tests

- New `l1_badproject` mock mode emits a real `session_path` with a deliberately wrong `project`.
- New `test_normalize_project` asserts the wrong value is overwritten with the session-dir basename and the run logs the normalization.
- Full suite green: **50/50**.