### PR TITLE
fix: self-audit denominator, big-transcript stripping, fast-elapsed disambiguation

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -280,10 +280,24 @@ dispatch_l1() { # one parallel pass; idempotent worker → only the still-missin
     else
       [ -n "$slimfile" ] && rm -f "$slimfile"
       # Worker exited without writing findings JSON. Record a diagnostic so the
-      # failure is visible (no more silent zero-byte .err files). Leave $output
-      # absent so a re-run retries this (possibly transient) session.
+      # failure is visible.
       printf "worker produced no findings JSON for %s (incomplete run: claude exited without writing output)\n" "$session" >> "$errlog"
-      echo "FAIL: $session ($hash) — see $errlog" >&2
+      # On the FINAL retry round, fall back to a metadata-only findings stub so
+      # the session is visible to L1_ERRORED and the L2 aggregator instead of
+      # disappearing into a silent .err file (the old behavior, which the
+      # 2026-06-11 self-audit flagged: 12 .err with l1_findings_with_error=0).
+      # Earlier rounds leave $output absent so the next round can retry; only
+      # the last round writes the stub. AUTODREAM_L1_ROUNDS comes through the
+      # environment (exported below).
+      if [ "${AUTODREAM_CURRENT_ROUND:-1}" -ge "${AUTODREAM_L1_ROUNDS:-5}" ]; then
+        sz=$(wc -c < "$session" 2>/dev/null | tr -d " ")
+        lines=$(wc -l < "$session" 2>/dev/null | tr -d " ")
+        printf "{\"session_path\":\"%s\",\"error\":\"worker exited without findings JSON after %s rounds\",\"meta\":{\"bytes\":%s,\"lines\":%s,\"slimmed\":%s},\"findings\":[]}\n" \
+          "$session" "${AUTODREAM_L1_ROUNDS:-5}" "${sz:-0}" "${lines:-0}" "$([ -n "$slimfile" ] && echo true || echo false)" > "$output"
+        echo "FAIL (metadata stub written): $session ($hash) — see $errlog" >&2
+      else
+        echo "FAIL: $session ($hash) — see $errlog" >&2
+      fi
     fi
   ' _ {}
 }
@@ -362,14 +376,29 @@ EOF
   # call inherit it.
   export CLAUDE_CODE_DISABLE_CLAUDE_MDS=1 DISABLE_TELEMETRY=1 DISABLE_ERROR_REPORTING=1
   export CLAUDE_BIN AUTODREAM_DIR FINDINGS_DIR SLIM WORK_DIR
+  # AUTODREAM_L1_ROUNDS is referenced by the dispatcher subshell to decide
+  # whether this is the last retry round (gates the metadata-stub fallback).
+  export AUTODREAM_L1_ROUNDS
 
   clean_work_bucket  # start clean: drop any stub left by a prior run's workers
+
+  # Pre-L1 cache snapshot: how many sessions in the worklist already have a valid
+  # findings JSON before any worker runs. Without this, a re-run after a partial
+  # crash shows an "impossible" l1_elapsed_seconds (e.g. 2s for 36 sessions)
+  # because the dispatcher's idempotent skip exits every worker instantly. The
+  # aggregator's self-audit needs this to disambiguate "fast run" from "broken
+  # timer".
+  L1_PRECACHED=$(l1_missing_count)
+  L1_PRECACHED=$(( COUNT - L1_PRECACHED ))
 
   L1_START=$(date +%s)
   L1_ROUNDS="${AUTODREAM_L1_ROUNDS:-5}"
   MISSING=$COUNT
   for round in $(seq 1 "$L1_ROUNDS"); do
     log "L1 triage round $round/$L1_ROUNDS (fanout=$FANOUT)..."
+    # The dispatcher's subshell reads this to decide whether the last-round
+    # metadata-stub fallback should fire for sessions that produced no output.
+    export AUTODREAM_CURRENT_ROUND="$round"
     dispatch_l1
     MISSING=$(l1_missing_count)
     L1_DONE=$(ls -1 "$FINDINGS_DIR"/*.json 2>/dev/null | wc -l | tr -d " ")
@@ -396,18 +425,37 @@ EOF
   # own (already excluded), how many workers failed, how many retry rounds it took.
   # Surface it so PROMPT.md's "Autodream self-audit" section can flag regressions
   # (e.g. the self-pollution exclusion count climbing again) and propose source fixes.
+  # Sessions enumerated by find but unaccounted for at run end — not pruned as
+  # self/empty, not in findings. This is the gap the 2026-06-11 self-audit
+  # caught: 12 .err files existed but stats showed l1_missing_after_retries=0
+  # because both denominators counted from the POST-prune sessions.txt. By
+  # computing against RAW and subtracting the legitimate prunes, any session
+  # lost to a filter mis-classification or silent worker death surfaces here.
+  # Bounded at 0 in case of a counting bug in the prunes.
+  DROPPED_AFTER_FAILURES=$(( RAW - L1_OK - EXCLUDED - SKIPPED_EMPTY ))
+  [ "$DROPPED_AFTER_FAILURES" -lt 0 ] && DROPPED_AFTER_FAILURES=0
+  L1_FRESHLY_PROCESSED=$(( L1_OK - L1_PRECACHED ))
+  [ "$L1_FRESHLY_PROCESSED" -lt 0 ] && L1_FRESHLY_PROCESSED=0
   {
     printf '# Autodream run self-audit — %s\n' "$TARGET_DATE"
     printf 'sessions_found_raw: %s\n' "$RAW"
     printf 'self_sessions_excluded: %s\n' "$EXCLUDED"
     printf 'sessions_skipped_empty: %s\n' "$SKIPPED_EMPTY"
     printf 'sessions_triaged: %s\n' "$COUNT"
+    # vs.-raw denominator: a session lost to ANY path (prune mis-classification,
+    # silent worker death, slim leftovers) shows up here. Always >= 0; if
+    # nonzero, the aggregator should investigate even when l1_missing=0.
+    printf 'sessions_dropped_after_failures: %s\n' "$DROPPED_AFTER_FAILURES"
     printf 'l1_rounds_used: %s\n' "$round"
     printf 'l1_rounds_max: %s\n' "$L1_ROUNDS"
     printf 'l1_findings_written: %s\n' "$L1_OK"
     printf 'l1_findings_with_error: %s\n' "$L1_ERRORED"
     printf 'l1_missing_after_retries: %s\n' "$MISSING"
     printf 'l1_err_files: %s\n' "$L1_FAIL"
+    # Cached vs. fresh: lets the aggregator distinguish a sub-second "elapsed"
+    # caused by everything already being done from a broken timer.
+    printf 'l1_sessions_already_done_at_start: %s\n' "$L1_PRECACHED"
+    printf 'l1_sessions_freshly_processed: %s\n' "$L1_FRESHLY_PROCESSED"
     printf 'l1_elapsed_seconds: %s\n' "$L1_ELAPSED"
   } > "$FINDINGS_DIR/run-stats.txt"
 

--- a/bin/slim-transcript.sh
+++ b/bin/slim-transcript.sh
@@ -29,15 +29,51 @@ cap="${AUTODREAM_SLIM_CAP:-262144}"
 lines=$(wc -l < "$src" | tr -d ' ')
 bytes=$(wc -c < "$src" | tr -d ' ')
 
+# Pre-pass: when jq is available, strip the bulky payloads inside tool_result
+# entries (and base64 image_url data) before the line-based head/tail/truncate
+# pass. Orchestrator/review-fan-out transcripts spend most of their bytes on
+# tool_result blocks (entire diffs, file dumps, gh JSON), so cutting just the
+# *.message.content tool_result fields shrinks the file 5-20x while leaving the
+# turn structure intact for fuzzy pattern-spotting. The line-based pass below
+# still runs as a safety net (caps stragglers like assistant turns that paste
+# huge code blocks). Falls back transparently if jq isn't installed or the
+# stream isn't pure JSONL (e.g. a non-Claude session schema we don't know).
+pre_src="$src"
+pre_tmp=""
+if command -v jq >/dev/null 2>&1; then
+  pre_tmp="$dst.pre.jsonl"
+  if jq -c '
+    if (.message.content | type) == "array" then
+      .message.content |= map(
+        if .type == "tool_result" then
+          # Replace the heavy content array with a one-line marker, preserve
+          # tool_use_id + is_error so triage can still tell which call failed.
+          .content = "[autodream: tool_result payload stripped]"
+        elif .type == "image" or .type == "image_url" then
+          .source = "[autodream: image stripped]"
+        else . end
+      )
+    else . end
+  ' "$src" > "$pre_tmp" 2>/dev/null && [ -s "$pre_tmp" ]; then
+    pre_src="$pre_tmp"
+    # Re-measure: head/tail/cap math below should reflect post-strip size.
+    lines=$(wc -l < "$pre_src" | tr -d ' ')
+  else
+    rm -f "$pre_tmp"; pre_tmp=""
+  fi
+fi
+
 {
   if [ "$lines" -le $((headn + tailn)) ]; then
-    cut -c1-"$maxline" "$src"
+    cut -c1-"$maxline" "$pre_src"
   else
-    head -n "$headn" "$src" | cut -c1-"$maxline"
+    head -n "$headn" "$pre_src" | cut -c1-"$maxline"
     printf '...[%d of %d lines elided by autodream for size]...\n' $((lines - headn - tailn)) "$lines"
-    tail -n "$tailn" "$src" | cut -c1-"$maxline"
+    tail -n "$tailn" "$pre_src" | cut -c1-"$maxline"
   fi
 } | head -c "$cap" > "$dst"
+
+[ -n "$pre_tmp" ] && rm -f "$pre_tmp"
 
 printf '\n...[autodream slimmed this transcript: original %s bytes / %s lines; lines truncated to %s chars]...\n' \
   "$bytes" "$lines" "$maxline" >> "$dst"

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -82,8 +82,14 @@ test_incomplete(){
   local root; root=$(setup_env); mk_session "$root" sess1
   export MOCK_MODE=l1_incomplete; run_dream "$root"; unset MOCK_MODE
   local h; h=$(hash_of "$root/projects/proj-a/sess1.jsonl")
-  assert_no_file  "$(fdir "$root")/$h.json"     "no output JSON (left absent so a re-run retries)"
-  assert_nonempty "$(fdir "$root")/$h.json.err" ".err is non-empty (no silent zero-byte file)"
+  # After the 2026-06-11 self-audit fix: on the FINAL retry round, a worker
+  # that produced no output gets a metadata-only stub so the session is
+  # visible to L1_ERRORED and the L2 aggregator instead of becoming a silent
+  # .err. Earlier rounds still left the slot absent so retries could fire.
+  assert_file     "$(fdir "$root")/$h.json"     "final-round stub written (no longer a silent failure)"
+  assert_grep     "$(fdir "$root")/$h.json"     'worker exited without findings JSON' "stub carries the failure reason"
+  assert_grep     "$(fdir "$root")/$h.json"     '"findings":\[\]'                     "stub has an empty findings array (counted by L1_ERRORED via the error key)"
+  assert_nonempty "$(fdir "$root")/$h.json.err" ".err is still non-empty (per-round diagnostics)"
   assert_grep     "$(fdir "$root")/$h.json.err" 'incomplete run' ".err carries a diagnostic"
   assert_file     "$root/dreams/$DATE.md"       "L2 still produced the report"
   rm -rf "$root"
@@ -101,6 +107,37 @@ test_self_audit_stats(){
   assert_grep  "$stats" 'self_sessions_excluded: 1' "stats record the excluded self-session"
   assert_grep  "$stats" 'sessions_triaged: 1'        "stats record the triaged count"
   assert_grep  "$stats" 'l1_findings_with_error: 0'  "stats record the in-band error count"
+  # 2026-06-11 self-audit fix: vs.-raw denominator + cache-disambiguating fields.
+  assert_grep  "$stats" 'sessions_dropped_after_failures: 0'   "no dropped sessions on a clean happy-path run"
+  assert_grep  "$stats" 'l1_sessions_already_done_at_start: 0' "no precached findings on a fresh run"
+  assert_grep  "$stats" 'l1_sessions_freshly_processed: 1'     "the one session was freshly processed this run"
+  rm -rf "$root"
+}
+
+test_self_audit_stats_failure_denominator(){
+  echo "# self-audit stats: dropped-after-failures is nonzero when a worker dies"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  export MOCK_MODE=l1_incomplete; run_dream "$root"; unset MOCK_MODE
+  local stats="$(fdir "$root")/run-stats.txt"
+  assert_file  "$stats" "run-stats.txt written"
+  # After the fix, even a stubbed final-round failure is counted: the stub
+  # carries an "error" key so it lands in l1_findings_with_error, AND the
+  # vs.-raw denominator stays accurate. Old behavior reported zero across
+  # the board even though the session never produced real findings.
+  assert_grep  "$stats" 'l1_findings_with_error: 1' "stats now surface the failed session via the error key"
+  rm -rf "$root"
+}
+
+test_self_audit_stats_precached_disambiguation(){
+  echo "# self-audit stats: precached findings counted so fast elapsed isn't 'impossible'"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  local h; h=$(hash_of "$root/projects/proj-a/sess1.jsonl")
+  # Pre-seed a valid findings JSON so dispatcher's idempotency skips the worker.
+  mkdir -p "$(fdir "$root")"; printf '{"session_path":"CACHED","findings":[]}' > "$(fdir "$root")/$h.json"
+  run_dream "$root"
+  local stats="$(fdir "$root")/run-stats.txt"
+  assert_grep  "$stats" 'l1_sessions_already_done_at_start: 1' "precached session counted as already done"
+  assert_grep  "$stats" 'l1_sessions_freshly_processed: 0'     "no fresh work this run"
   rm -rf "$root"
 }
 
@@ -318,6 +355,8 @@ test_skip_empty_disabled
 test_l1_retry
 test_idempotency_guard
 test_self_audit_stats
+test_self_audit_stats_failure_denominator
+test_self_audit_stats_precached_disambiguation
 test_slim_transcript
 echo
 echo "----------------------------------------"


### PR DESCRIPTION
## Summary

Three fixes from the 2026-06-11 autodream self-audit:

- **Denominator bug.** Both `sessions_triaged` and `l1_missing_after_retries` counted against the post-prune `sessions.txt`, so a session lost to a filter mis-classification or a silent worker death disappeared from stats (the audit caught 12 `.err` files with `l1_missing=0` and `l1_findings_with_error=0`). Adds `sessions_dropped_after_failures = RAW - L1_OK - EXCLUDED - SKIPPED_EMPTY` — any enumerated session that didn't end up in findings or a legitimate prune surfaces here.
- **Big-transcript worker deaths.** `bin/slim-transcript.sh` adds a `jq` pre-pass that strips `tool_result` content payloads (and image data) before the line-based head/tail/truncate pass. On orchestrator / review-fan-out transcripts this is ~5-20× more effective than line truncation alone, since the bulky middle is `tool_result` blocks, not assistant prose. Falls back to the original line pass when `jq` is unavailable or the schema doesn't match. Paired with a metadata-only fallback in `dispatch_l1`: on the final retry round, a worker that exits without findings writes a stub `{session_path, error, meta:{bytes,lines,slimmed}, findings:[]}` so the session lands in `L1_FINDINGS_WITH_ERROR` and the L2 aggregator instead of becoming a silent `.err`.
- **Telemetry / fast-elapsed disambiguation.** `l1_elapsed_seconds: 2` was reported as "impossible" for 36 sessions, but the timer was correct — every session was already cached from a prior partial run and the dispatcher's idempotent skip exited each worker instantly. Adds `l1_sessions_already_done_at_start` and `l1_sessions_freshly_processed` so the aggregator can distinguish a fast cached run from a broken timer.

## Why now

These three together blind the daily report to the actual triage failure rate. The denominator fix is the most important — once `sessions_dropped_after_failures` shows up, future audits will see whether big-transcript deaths are getting worse or better, which decides how much engineering the slimmer pass deserves.

## Test plan

- [x] `bash tests/run-all.sh` — 63/63 passing
- [x] Updated `test_incomplete` to expect the new metadata stub on the final round
- [x] Added `test_self_audit_stats_failure_denominator` — confirms `l1_findings_with_error` is `1` for a single-session failure run
- [x] Added `test_self_audit_stats_precached_disambiguation` — confirms `l1_sessions_already_done_at_start: 1` / `l1_sessions_freshly_processed: 0` for a pre-cached session
- [x] Extended `test_self_audit_stats` to assert the three new fields on the happy path
- [ ] Run against a real night's findings dir to confirm `sessions_dropped_after_failures` matches `wc -l findings/<date>/*.err`
