### PR TITLE
fix: review.sh follow-ups from code review

### DIFF
--- a/bin/review.sh
+++ b/bin/review.sh
@@ -56,12 +56,20 @@ for arg in "$@"; do
   case "$arg" in
     --force|-f) FORCE=1 ;;
     -h|--help)
-      # Lines 2-15 are the description, usage, and the skip rationale. Keep this
-      # range in sync if the header comment grows.
-      sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+      # Print the header comment block verbatim: everything from line 2 until the
+      # first non-comment line. Derived rather than a line range, so growing the
+      # header cannot silently truncate --help mid-sentence.
+      awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"
       exit 0 ;;
     -*) echo "review.sh: unknown option: $arg" >&2; exit 2 ;;
-    *)  POSITIONAL="$arg" ;;
+    *)
+      # One report per run. Silently triaging only the last of several dates
+      # would be a confusing way to lose a request.
+      if [ -n "$POSITIONAL" ]; then
+        echo "review.sh: expected one date, got '$POSITIONAL' and '$arg'" >&2
+        exit 2
+      fi
+      POSITIONAL="$arg" ;;
   esac
 done
 
@@ -90,7 +98,7 @@ DATE=$(basename "$REPORT" .md)
 # gate this run."). The fallback only ever recognises a shape it is sure about;
 # everything else is "unknown" rather than a guess.
 report_open_questions(){
-  report="$1"
+  local report="$1" marker section first
 
   marker=$(sed -n 's/.*<!-- *autodream:open-questions=\([0-9][0-9]*\) *-->.*/\1/p' "$report" | head -1)
   if [ -n "$marker" ]; then printf '%s\n' "$marker"; return 0; fi
@@ -124,18 +132,22 @@ skip_notice(){
 }
 
 if [ "$FORCE" -eq 0 ]; then
-  QUESTIONS=$(report_open_questions "$REPORT")
-  if [ "$QUESTIONS" = "0" ]; then
-    skip_notice "no open questions, nothing to triage."
-    exit 0
-  fi
+  # Triage state first: a report can be both empty and already worked through
+  # (an empty-day stub someone closed out), and "already triaged" is the more
+  # informative reason of the two.
   if report_is_triaged "$REPORT"; then
     COUNT=$(report_triage_count "$REPORT" | tr -d ' ')
-    if [ "$COUNT" -gt 0 ] 2>/dev/null; then
+    if [ "$COUNT" -eq 1 ] 2>/dev/null; then
+      skip_notice "already triaged (1 decision logged)."
+    elif [ "$COUNT" -gt 1 ] 2>/dev/null; then
       skip_notice "already triaged ($COUNT decisions logged)."
     else
       skip_notice "already triaged."
     fi
+    exit 0
+  fi
+  if [ "$(report_open_questions "$REPORT")" = "0" ]; then
+    skip_notice "no open questions, nothing to triage."
     exit 0
   fi
 fi

--- a/tests/review-skip.sh
+++ b/tests/review-skip.sh
@@ -56,6 +56,18 @@ run_review(){ # $1=root ; rest = args
   [ -f "$root/launched" ] && printf 'launched' || printf 'skipped'
 }
 
+# Same invocation, but returns review.sh's own exit code instead of a verdict.
+# run_review cannot be used for this: its exit status is the verdict printf's.
+run_review_rc(){ # $1=root ; rest = args
+  local root="$1"; shift
+  LAUNCH_MARKER="$root/launched" \
+  AUTODREAM_CONFIG="$root/nonexistent-config" \
+  AUTODREAM_TRIAGE_SURFACE=inline \
+  DREAMS_DIR="$root/dreams" \
+  CLAUDE_BIN="$root/bin/claude" \
+  bash "$REVIEW" "$@" > "$root/out" 2>&1
+}
+
 # --- fixture bodies --------------------------------------------------------
 
 REPORT_MARKER_ZERO='# Autodream — 2020-01-02
@@ -93,6 +105,16 @@ REPORT_STUB='# Autodream — 2020-01-02
 No Claude Code sessions were modified on this date.
 
 (Generated 2020-01-03T07:00:06Z)'
+
+# An empty day that someone already closed out (see the real 2026-06-27). Both
+# skip reasons apply; "already triaged" is the one worth printing.
+REPORT_STUB_TRIAGED='# Autodream — 2020-01-02
+
+No Claude Code sessions were modified on this date.
+
+## Triage decisions
+
+- 2020-01-03: No sessions modified. Nothing to triage; session closed.'
 
 REPORT_NO_SECTION='# Autodream — 2020-01-02
 
@@ -192,8 +214,38 @@ test_latest_report_default(){
   local root; root=$(setup_env)
   mk_report "$root" 2020-01-01 "$REPORT_MARKER_THREE"
   mk_report "$root" 2020-01-02 "$REPORT_MARKER_ZERO"
-  touch "$root/dreams/2020-01-02.md"   # ensure it is newest
+  # Stamp both explicitly. Writing them in order is not enough: review.sh picks
+  # the latest with `ls -t`, and two files written in the same instant tie —
+  # BSD ls then breaks the tie by name, which would pick the wrong report.
+  touch -t 202001011200 "$root/dreams/2020-01-01.md"
+  touch -t 202001021200 "$root/dreams/2020-01-02.md"
   assert_eq "$(run_review "$root")" skipped "no-arg run resolves the latest report and skips it"
+}
+
+test_stub_triaged_prefers_triaged_reason(){
+  local root; root=$(setup_env)
+  mk_report "$root" 2020-01-02 "$REPORT_STUB_TRIAGED"
+  assert_eq "$(run_review "$root" 2020-01-02)" skipped "stub that was already triaged skips"
+  assert_grep "$root/out" 'already triaged (1 decision logged)' "prefers the triaged reason, and says decision not decisions"
+}
+
+test_two_dates_error(){
+  local root; root=$(setup_env)
+  mk_report "$root" 2020-01-01 "$REPORT_MARKER_THREE"
+  mk_report "$root" 2020-01-02 "$REPORT_MARKER_THREE"
+  local rc=0
+  run_review_rc "$root" 2020-01-01 2020-01-02 || rc=$?
+  assert_grep "$root/out" 'expected one date' "two dates is an error, not a silent pick"
+  assert_eq "$rc" 2 "two dates exits 2"
+}
+
+# --help is built from the header comment block, so it must not stop mid-thought.
+test_help_is_complete(){
+  local root; root=$(setup_env)
+  run_review_rc "$root" --help
+  assert_grep "$root/out" 'Usage: review.sh' "help includes the usage block"
+  assert_grep "$root/out" 'force bypasses it' "help includes the end of the skip rationale"
+  assert_grep "$root/out" 'config overrides defaults' "help runs to the end of the header"
 }
 
 test_missing_report_errors(){
@@ -216,6 +268,9 @@ test_stub_skips
 test_unknown_launches
 test_triaged_skips
 test_triaged_numbered_skips
+test_stub_triaged_prefers_triaged_reason
+test_two_dates_error
+test_help_is_complete
 test_force_overrides
 test_latest_report_default
 test_missing_report_errors


### PR DESCRIPTION
Follow-ups from the `/code-review` pass on #17. None of these broke the skip decision, which is why #17 merged as-is. One of them had already bitten once during that work, and dry-running the fixes over the real reports turned up a sixth.

## What changed

`--help` was built from a hardcoded `sed -n '2,15p'` range. The header grew during #17 and the help output started stopping mid-sentence, which I fixed by bumping the range to 15 and leaving a comment asking the next person to keep it in sync. That's not a fix, that's a tripwire. It now prints the header comment block up to the first non-comment line, so it can't drift again.

Extra positional args collapsed to the last one, so `review.sh 2026-07-01 2026-07-02` quietly triaged only 07-02. Now an error, exit 2.

`report_open_questions` assigned `report`, `marker`, `section` and `first` without `local`. Nothing depends on it today, but `report` is a generic enough name to collide with a future edit.

The skip checks ran questions-first, so a report that's both an empty-day stub and already triaged reported "no open questions" when "already triaged" says more. Your real 2026-06-27 is exactly that shape. Triage state is checked first now.

Dry-running that reorder over `~/.claude/dreams/` immediately printed `already triaged (1 decisions logged)`, so the notice pluralizes properly.

`test_latest_report_default` wrote both fixtures back to back and leaned on `ls -t` to pick the newer one. It passes because APFS timestamps are nanosecond-resolution, but the `touch` in there was a tie-breaker that didn't break ties: a genuine collision sorts `2020-01-01` first and flips the assertion. Both fixtures get explicit `touch -t` stamps.

## Before and after, on the real reports

| report | before | after |
|---|---|---|
| 2026-06-27 | no open questions | already triaged (1 decision logged) |
| 2026-07-14 | no open questions | already triaged (2 decisions logged) |
| 2026-07-15 | no open questions | no open questions (unchanged, not triaged) |

## Tests

23 pass, 7 of them new: the stub-plus-triaged precedence, the two-date error and its exit code, and three asserting `--help` runs from the usage block through to the end of the header. `run-all.sh` still 67.

Worth noting `run_review` couldn't test the exit code: it returns its own verdict `printf`'s status, not review.sh's. There's a `run_review_rc` helper for that now.
