### PR TITLE
feat: mechanical pre-pass computes session stats before L1 (#6)

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -64,6 +64,9 @@ PRUNE="$SCRIPT_DIR/prune-self-sessions.sh"
 # Oversized-transcript slimmer (resolved the same way; exported to the L1 workers).
 SLIM="$SCRIPT_DIR/slim-transcript.sh"
 [ -x "$SLIM" ] || SLIM="$AUTODREAM_DIR/slim-transcript.sh"
+# Deterministic session-stat pre-pass (resolved like the other helper scripts).
+STATS="$SCRIPT_DIR/session-stats.sh"
+[ -x "$STATS" ] || STATS="$AUTODREAM_DIR/session-stats.sh"
 
 mkdir -p "$FINDINGS_DIR" "$DREAMS_DIR" "$LOG_DIR" "$WORK_DIR"
 
@@ -200,6 +203,28 @@ l1_missing_count() { # count sessions in $SESSIONS_LIST that still have no findi
   printf '%s' "$m"
 }
 
+findings_json_count() {
+  find "$FINDINGS_DIR" -type f -name '*.json' ! -name '*.stats.json' 2>/dev/null \
+    | wc -l | tr -d ' '
+}
+
+compute_session_stats() {
+  local session hash stats
+  while IFS= read -r session; do
+    [ -n "$session" ] || continue
+    hash=$(printf "%s" "$session" | shasum -a 1 | cut -c1-12)
+    stats="$FINDINGS_DIR/$hash.stats.json"
+    rm -f "$stats"
+    if [ -x "$STATS" ] && "$STATS" "$session" "$stats" >/dev/null 2>&1 \
+      && [ -s "$stats" ] && jq -e 'type == "object"' "$stats" >/dev/null 2>&1; then
+      echo "stats: $session ($hash)" >&2
+    else
+      rm -f "$stats"
+      echo "stats failed: $session ($hash); continuing without precomputed stats" >&2
+    fi
+  done < "$SESSIONS_LIST"
+}
+
 dispatch_l1() { # one parallel pass; idempotent worker → only the still-missing sessions run
   < "$SESSIONS_LIST" xargs -P "$FANOUT" -I {} bash -c '
     session="$1"
@@ -256,6 +281,11 @@ dispatch_l1() { # one parallel pass; idempotent worker → only the still-missin
       printf "Session transcript to analyze (literal absolute path): %s\n" "$readpath"
       printf "Write your findings JSON to this literal absolute path: %s\n\n" "$output"
       cat "$AUTODREAM_DIR/SESSION_TRIAGE.md"
+      if [ -s "$FINDINGS_DIR/$hash.stats.json" ]; then
+        printf "\n## Precomputed session stats (authoritative — copy these into your output)\n\n\`\`\`json\n"
+        cat "$FINDINGS_DIR/$hash.stats.json"
+        printf "\n\`\`\`\n"
+      fi
     } | "$CLAUDE_BIN" \
       --print \
       --permission-mode bypassPermissions \
@@ -366,6 +396,10 @@ EOF
     return 0
   fi
 
+  # Compute once from the final enumeration. Retry rounds reuse these sidecars;
+  # they are intentionally not regenerated during dispatch retries.
+  compute_session_stats
+
   # ---- Layer 1: haiku triage, parallel, retried across sleep/network gaps ----
   # Lean-query env (claude-cells internal/claude/query.go pattern): keep subscription
   # OAuth auth but strip per-call bloat — no CLAUDE.md auto-load, no telemetry/error
@@ -401,7 +435,7 @@ EOF
     export AUTODREAM_CURRENT_ROUND="$round"
     dispatch_l1
     MISSING=$(l1_missing_count)
-    L1_DONE=$(ls -1 "$FINDINGS_DIR"/*.json 2>/dev/null | wc -l | tr -d " ")
+    L1_DONE=$(findings_json_count)
     log "L1 round $round: $L1_DONE done, $MISSING still missing"
     [ "$MISSING" -eq 0 ] && break
     if [ "$round" -lt "$L1_ROUNDS" ]; then
@@ -411,13 +445,14 @@ EOF
     fi
   done
   L1_ELAPSED=$(( $(date +%s) - L1_START ))
-  L1_OK=$(ls -1 "$FINDINGS_DIR"/*.json 2>/dev/null | wc -l | tr -d " ")
+  L1_OK=$(findings_json_count)
   L1_FAIL=$(ls -1 "$FINDINGS_DIR"/*.json.err 2>/dev/null | wc -l | tr -d " ")
   # In-band failures: a worker that ran to completion but couldn't fit the transcript
   # writes a findings JSON carrying a top-level "error" key (empty findings). These are
   # NOT .json.err files, so l1_err_files=0 masked them — count them explicitly so the
   # self-audit can alarm on a high extraction-failure rate (slimming should drive →0).
-  L1_ERRORED=$(grep -l '"error":' "$FINDINGS_DIR"/*.json 2>/dev/null | wc -l | tr -d " ")
+  L1_ERRORED=$(find "$FINDINGS_DIR" -type f -name '*.json' ! -name '*.stats.json' \
+    -exec grep -l '"error":' {} + 2>/dev/null | wc -l | tr -d " ")
   log "L1 done in ${L1_ELAPSED}s: $L1_OK done ($L1_ERRORED with errors), $MISSING missing (.err files: $L1_FAIL)"
 
   # ---- Normalize the project field deterministically from the session path ----

--- a/bin/session-stats.sh
+++ b/bin/session-stats.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Deterministic, model-free session statistics sidecar for cc-autodream L1 triage.
+
+set -u
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <transcript.jsonl> <out.stats.json>" >&2
+  exit 2
+fi
+
+transcript="$1"
+output="$2"
+
+[ -r "$transcript" ] || {
+  echo "session-stats: transcript is not readable: $transcript" >&2
+  exit 1
+}
+
+bytes=$(wc -c < "$transcript" | tr -d ' ')
+mtime=$(stat -f %m "$transcript" 2>/dev/null) || {
+  echo "session-stats: could not read transcript mtime: $transcript" >&2
+  exit 1
+}
+
+mkdir -p "$(dirname "$output")" || exit 1
+
+jq -R -s \
+  --argjson transcript_bytes "${bytes:-0}" \
+  --argjson transcript_mtime "${mtime:-0}" \
+  '
+  [
+    split("\n")[]
+    | fromjson?
+    | select(type == "object")
+  ] as $lines
+  | [
+      $lines[]
+      | select(.type == "user" and .isMeta != true)
+      | .message.content
+      | select(
+          type == "string"
+          or (
+            type == "array"
+            and any(.[]?; .type == "text")
+            and all(.[]?; .type != "tool_result")
+          )
+        )
+    ] as $user_messages
+  | [
+      $lines[]
+      | select(.isMeta != true and (.type == "user" or .type == "assistant"))
+    ] as $turns
+  | [
+      $lines[]
+      | select(.type == "assistant" and (.message.content | type) == "array")
+      | .message.content[]
+      | select(.type == "tool_use")
+    ] as $tool_uses
+  | [
+      $lines[]
+      | select(.type == "assistant")
+      | .message.model
+      | select(type == "string" and length > 0 and . != "<synthetic>")
+    ] as $models
+  | [
+      $lines[]
+      | select(has("timestamp"))
+      | .timestamp
+      | select(type == "string")
+      | try (sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) catch empty
+    ] as $timestamps
+  | [
+      $lines[]
+      | select(.type == "assistant" and (.message.content | type) == "array")
+      | .message.content[]
+      | select(.type == "text" and (.text | type) == "string")
+      | .text
+    ]
+    | join("") as $assistant_text
+  | {
+      user_message_count: ($user_messages | length),
+      turn_count: ($turns | length),
+      tool_call_count: ($tool_uses | length),
+      tools_used: (
+        $tool_uses
+        | map(.name)
+        | map(select(type == "string"))
+        | unique
+        | sort
+      ),
+      models_used: ($models | unique | sort),
+      duration_minutes: (
+        if ($timestamps | length) < 2 then 0
+        else (((($timestamps | max) - ($timestamps | min)) / 60) * 10 | round) / 10
+        end
+      ),
+      compliance_markers: {
+        "RETRY-BUDGET": (($assistant_text | split("RETRY-BUDGET:") | length) - 1),
+        "FETCH-PIVOT": (($assistant_text | split("FETCH-PIVOT:") | length) - 1)
+      },
+      transcript_bytes: $transcript_bytes,
+      transcript_mtime: $transcript_mtime,
+      isSidechain: (any($lines[]?; .isSidechain == true))
+    }
+  ' "$transcript" > "$output"

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,7 @@ link "$REPO_DIR/bin/notify.sh"          "$TARGET/notify.sh"
 link "$REPO_DIR/bin/make-notifier.sh"   "$TARGET/make-notifier.sh"
 link "$REPO_DIR/bin/prune-self-sessions.sh" "$TARGET/prune-self-sessions.sh"
 link "$REPO_DIR/bin/slim-transcript.sh"     "$TARGET/slim-transcript.sh"
+link "$REPO_DIR/bin/session-stats.sh"        "$TARGET/session-stats.sh"
 link "$REPO_DIR/prompts/PROMPT.md"      "$TARGET/PROMPT.md"
 link "$REPO_DIR/prompts/SESSION_TRIAGE.md" "$TARGET/SESSION_TRIAGE.md"
 

--- a/prompts/PROMPT.md
+++ b/prompts/PROMPT.md
@@ -15,7 +15,7 @@ These are plain text values, **not shell variables**. Use them as literal paths 
 
 All other inputs you need (treat `<findings-dir>` below as the literal path from line 1):
 
-- **Per-session findings JSONs**: every file matching `<findings-dir>/*.json` (Glob it) is one session's structured output (schema in `SESSION_TRIAGE.md`). Read them all.
+- **Per-session findings JSONs**: every file matching `<findings-dir>/*.json` except `*.stats.json` (Glob it) is one session's structured output (schema in `SESSION_TRIAGE.md`). Read them all.
 - **Per-session stderr**: `<findings-dir>/*.json.err` if a triage call failed — note in your report.
 - **Installed skills**: walk `~/.claude/skills/`, `~/.claude/plugins/*/skills/`, and project `.claude/skills/`. Each has frontmatter `description`/triggers. Use this to validate `missed_skill` findings (skill exists? trigger matches?).
 - **Memory files**: `~/.claude/projects/*/memory/MEMORY.md` (one per project — may not exist).
@@ -84,6 +84,7 @@ cc-autodream is its author's own project — turn the lens on the pipeline itsel
 - **Pipeline capacity**: `l1_findings_with_error` counts sessions that ran to completion but returned empty `findings` with an `error` (transcript too big to fit, even after slimming) — a silent failure that `l1_err_files` (crashed-worker `.err` files) does NOT capture. If it is a meaningful fraction of `sessions_triaged`, call out the extraction-failure rate and propose the next cc-autodream fix (a `jq` pre-summarizer that strips verbose `tool_result` payloads, a lower `AUTODREAM_SLIM_BYTES`, or a metadata-only fallback pass).
 - **Retry/sleep health**: if `l1_rounds_used` approached `l1_rounds_max` or `l1_missing_after_retries > 0`, the run fought the network/sleep — note it (the laptop likely slept mid-run) and whether the report is complete.
 - **Recurring self-findings**: if cc-autodream sessions themselves surfaced patterns (the author working on the tool), give them first-class weight here rather than burying them in per-project notes.
+- **Turn-count semantics**: changed on 2026-07-20; `turn_count` now includes tool_result-carrier user lines. Do not flag the jump in Total turns as an anomaly.
 
 Keep it to what the stats and findings actually show; skip the section's sub-bullets that have nothing to report. If `run-stats.txt` is absent, say so and move on.
 
@@ -135,7 +136,7 @@ For findings with `confidence: high` AND `count >= 2` AND `severity: high`, you 
 ## How to start
 
 1. Read the findings directory's `*.json` files (use Glob then Read).
-2. Build an in-memory aggregate: group findings by category, count, sort by (count × severity). Also sum each session's `compliance_markers` counts (`RETRY-BUDGET`, `FETCH-PIVOT`) when present: markers measure the retry-budget rules working as designed. When reporting a `tool_loop` pattern, split marker-present sessions (rule fired — healthy) from marker-absent ones (the actual non-compliance) and state both counts. Also collect the facet fields when present: `outcome` and `satisfaction_signals` for the Activity-snapshot outcomes line, `underlying_goal` for Per-project notes, and the `instructions_given` lists for the cross-session repetition check (see Memory updates).
+2. Build an in-memory aggregate: group findings by category, count, sort by (count × severity). Exclude `*.stats.json` sidecars from the findings aggregate. Also sum each session's `compliance_markers` counts (`RETRY-BUDGET`, `FETCH-PIVOT`) when present: markers measure the retry-budget rules working as designed. When reporting a `tool_loop` pattern, split marker-present sessions (rule fired — healthy) from marker-absent ones (the actual non-compliance) and state both counts. Also collect the facet fields when present: `outcome` and `satisfaction_signals` for the Activity-snapshot outcomes line, `underlying_goal` for Per-project notes, and the `instructions_given` lists for the cross-session repetition check (see Memory updates).
 3. Walk installed skills (Glob `~/.claude/skills/*/SKILL.md` etc., Read frontmatter).
 4. Read `<findings-dir>/changelog-window.md` (Upstream changes) and `<findings-dir>/run-stats.txt` (Autodream self-audit) if present.
 5. Write the report to the literal report path from line 2.

--- a/prompts/SESSION_TRIAGE.md
+++ b/prompts/SESSION_TRIAGE.md
@@ -22,6 +22,8 @@ Then:
 3. **Write the JSON** with the Write tool to the literal output path from line 2 — exactly one JSON object, no prose around it.
 4. Print `done` and exit. No commentary.
 
+When present, a **Precomputed session stats** block follows this document at the end of the prompt. Its `turn_count`, `tool_call_count`, `tools_used`, `models_used`, and `compliance_markers` fields are authoritative: copy them verbatim into the output JSON. Do not derive or recount those fields from the transcript. If the block is absent, derive them from the transcript as before.
+
 ## What to look for
 
 Quote 1-3 sentences of evidence for every finding. Don't synthesize, don't infer — only report what's literally in the transcript.

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -37,7 +37,7 @@ setup_env(){
 }
 mk_session(){ # $1=root $2=name
   local f="$1/projects/proj-a/$2.jsonl"
-  printf '{"type":"user","cwd":"/tmp/proj-a"}\n{"type":"assistant"}\n' > "$f"
+  printf '{"type":"user","cwd":"/tmp/proj-a"}\n{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read"}]}}\n' > "$f"
   touch -t "$STAMP" "$f"
 }
 hash_of(){ printf '%s' "$1" | shasum -a 1 | cut -c1-12; }
@@ -54,12 +54,74 @@ fdir(){ printf '%s' "$1/autodream/findings/$DATE"; }   # findings dir for a root
 
 # ---------------------------------------------------------------------------
 
+test_session_stats(){
+  echo "# deterministic session stats pre-pass acceptance fixtures"
+  local root; root=$(mktemp -d "${TMPDIR:-/tmp}/ccad.XXXXXX")
+  local fixture out
+
+  fixture="$root/carriers.jsonl"; out="$root/carriers.stats.json"
+  printf '%s\n' \
+    '{"type":"user","message":{"role":"user","content":"human question"}}' \
+    '{"type":"assistant","message":{"model":"claude-haiku","content":[{"type":"tool_use","name":"Read"}]}}' \
+    '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"a","content":"result"}]}}' \
+    'not json' \
+    '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"b","content":"result"}]}}' > "$fixture"
+  "$REPO/bin/session-stats.sh" "$fixture" "$out"
+  assert_eq "$(jq -r 'keys | sort | join(",")' "$out")" \
+    "compliance_markers,duration_minutes,isSidechain,models_used,tool_call_count,tools_used,transcript_bytes,transcript_mtime,turn_count,user_message_count" \
+    "stats output has exactly the specified fields"
+  assert_eq "$(jq -r .user_message_count "$out")" "1" "tool_result carriers are excluded from user message count"
+  assert_eq "$(jq -r .turn_count "$out")" "4" "turn count includes tool_result carriers"
+
+  fixture="$root/timestamps.jsonl"; out="$root/timestamps.stats.json"
+  printf '%s\n' \
+    '{"type":"user","timestamp":"2026-07-20T10:00:00.500Z","message":{"content":"start"}}' \
+    '{"type":"system","message":{"content":"no timestamp needed"}}' \
+    '{"type":"assistant","message":{"model":"claude-opus","content":"middle"}}' \
+    '{"type":"progress","timestamp":"2026-07-20T10:01:00.250Z"}' \
+    '{"type":"assistant","timestamp":"2026-07-20T10:02:30.750Z","message":{"model":"<synthetic>","content":"end"}}' > "$fixture"
+  "$REPO/bin/session-stats.sh" "$fixture" "$out"
+  assert_eq "$(jq -r .duration_minutes "$out")" "2.5" "duration uses available fractional timestamps"
+  assert_eq "$(jq -r .models_used[0] "$out")" "claude-opus" "synthetic model is dropped"
+
+  fixture="$root/markers.jsonl"; out="$root/markers.stats.json"
+  printf '%s\n' \
+    '{"type":"user","message":{"content":"user pasted RETRY-BUDGET: not a marker"}}' \
+    '{"type":"user","message":{"content":[{"type":"tool_result","content":"payload RETRY-BUDGET: not a marker"}]}}' \
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"RETRY-BUDGET: real"}]}}' > "$fixture"
+  "$REPO/bin/session-stats.sh" "$fixture" "$out"
+  assert_eq "$(jq -r '.compliance_markers["RETRY-BUDGET"]' "$out")" "1" "only assistant text counts RETRY-BUDGET"
+
+  fixture="$root/text-image.jsonl"; out="$root/text-image.stats.json"
+  printf '%s\n' \
+    '{"type":"user","message":{"content":[{"type":"text","text":"caption"},{"type":"image","source":{"type":"base64","data":"abc"}}]}}' > "$fixture"
+  "$REPO/bin/session-stats.sh" "$fixture" "$out"
+  assert_eq "$(jq -r .user_message_count "$out")" "1" "text plus image human turn counts"
+
+  fixture="$root/sidechain.jsonl"; out="$root/sidechain.stats.json"
+  printf '%s\n' \
+    '{"type":"user","isSidechain":true,"message":{"content":"subagent task"}}' \
+    '{"type":"assistant","isSidechain":true,"message":{"model":"claude-haiku","content":[{"type":"tool_use","name":"Write"},{"type":"tool_use","name":"Bash"},{"type":"tool_use","name":"Read"}]}}' \
+    '{"type":"user","isSidechain":true,"message":{"content":[{"type":"tool_result","content":"one"}]}}' \
+    '{"type":"user","isSidechain":true,"message":{"content":[{"type":"tool_result","content":"two"}]}}' \
+    '{"type":"user","isSidechain":true,"message":{"content":[{"type":"tool_result","content":"three"}]}}' > "$fixture"
+  "$REPO/bin/session-stats.sh" "$fixture" "$out"
+  assert_eq "$(jq -r .user_message_count "$out")" "1" "sidechain has one human message"
+  assert_eq "$(jq -r .turn_count "$out")" "5" "sidechain turn count includes carriers"
+  assert_eq "$(jq -r .tool_call_count "$out")" "3" "sidechain tool calls are counted mechanically"
+  assert_eq "$(jq -r '.tools_used | join(",")' "$out")" "Bash,Read,Write" "sidechain tools are sorted and unique"
+  assert_eq "$(jq -r .isSidechain "$out")" "true" "sidechain marker is copied"
+  rm -rf "$root"
+}
+
 test_happy(){
   echo "# happy path"
   local root; root=$(setup_env); mk_session "$root" sess1
   run_dream "$root"
   local h; h=$(hash_of "$root/projects/proj-a/sess1.jsonl")
   assert_file    "$(fdir "$root")/$h.json"     "L1 wrote findings JSON"
+  assert_file    "$(fdir "$root")/$h.stats.json" "mechanical stats sidecar written"
+  assert_eq      "$(jq -r .tool_call_count "$(fdir "$root")/$h.stats.json")" "1" "sidecar has plausible tool_call_count"
   assert_no_file "$(fdir "$root")/$h.json.err" "no .err on success"
   assert_file    "$root/dreams/$DATE.md"       "L2 wrote the report"
   rm -rf "$root"
@@ -191,6 +253,13 @@ test_framing(){
   case "$l2" in "Write your findings JSON to this literal absolute path: /"*) ok "line 2 = literal output path" ;; *) no "line 2 framing (got [$l2])" ;; esac
   assert_eq "$l3" "" "line 3 = blank separator (doc not glued onto the path)"
   case "$l4" in "# Session Triage"*) ok "line 4 = SESSION_TRIAGE.md begins" ;; *) no "line 4 doc start (got [$l4])" ;; esac
+  local doc_line stats_line
+  doc_line=$(grep -n '^## Output schema' "$cap" | head -n 1 | cut -d: -f1)
+  stats_line=$(grep -n '^## Precomputed session stats' "$cap" | head -n 1 | cut -d: -f1)
+  [ -n "$doc_line" ] && [ -n "$stats_line" ] && [ "$stats_line" -gt "$doc_line" ] \
+    && ok "precomputed stats block follows the full SESSION_TRIAGE.md body" \
+    || no "precomputed stats block follows the full SESSION_TRIAGE.md body"
+  assert_grep "$cap" '"tool_call_count": 1' "captured L1 prompt contains the sidecar JSON"
   if printf '%s\n%s\n' "$l1" "$l2" | grep -qE 'SESSION_PATH=|OUTPUT_PATH=|[$]SESSION_PATH|[$]OUTPUT_PATH'; then
     no "no legacy KEY=value / \$VAR framing in the inlined header"
   else
@@ -376,6 +445,7 @@ test_facet_fields_plumbed(){
 echo "cc-autodream integration tests (mock claude)"
 echo
 test_happy
+test_session_stats
 test_unreadable
 test_incomplete
 test_idempotent


### PR DESCRIPTION
## Summary

Phase 2 of the /insights-parity epic (#15), opened by the #6-gate measurement: haiku miscounts mechanical fields badly (median delta 29% on `tool_call_count`, 67% on `turn_count` across 10 staleness-controlled sessions — [gate data](https://github.com/STRML/cc-autodream/issues/6#issuecomment-5027590788)). Closes #6.

- New `bin/session-stats.sh`: deterministic jq pre-pass computing `user_message_count`, `turn_count`, `tool_call_count`, `tools_used`, `models_used`, `duration_minutes`, `compliance_markers`, `transcript_bytes`, `transcript_mtime`, `isSidechain` per the spec's pinned derivation rules.
- `run.sh` computes a `<key>.stats.json` sidecar per session at enumeration (once per run; retry rounds reuse them) and appends the stats to the L1 prompt as an authoritative block AFTER the SESSION_TRIAGE.md body, preserving the line-1/2 framing contract. A missing or failed sidecar just skips the block — dispatch never blocks on it.
- `SESSION_TRIAGE.md` tells L1 to copy the block's fields verbatim when present and derive them only when absent. `PROMPT.md` gets the turn-count-semantics cutover note (turn_count now includes tool_result-carrier user lines) and excludes `*.stats.json` from the findings aggregate.
- Counting fix that fell out of the wiring: `L1_DONE`/`L1_OK`/`L1_ERRORED` now exclude sidecars so run-stats numbers stay truthful. Existing run-stats keys untouched.
- Note: stats come from the full original transcript even when L1 reads a slimmed copy — an accuracy improvement over haiku counting the slim.

## Status — 2026-07-20

| item | state | evidence |
|---|---|---|
| #6-gate | open (build justified) | issue #6 comment: medians 29.2% / 66.7% vs 5% threshold |
| Implementation | done | cf7f9c5 (codex gpt-5.6-luna high; spec-verified by Fable, 12/12 claims) |
| Tests | passing | `tests/run-all.sh` 89/89 (5 acceptance fixtures, framing-position assertion); `tests/review-skip.sh` 23/23 |
| Real-transcript check | passing | hand-counted transcript: 3 tool calls, 11 turns, 1 user message — sidecar matches exactly |
| CodeRabbit | absent | bot ignored PR #18 and a direct trigger; local review is the gate on this repo |

Open follow-ups:
- [ ] Merge authorization (local review gate; no CI on this repo)
- [ ] After merge: #7 (noise gate) and #14 (multi-clauding overlap) unblock — both depend on this pre-pass
- [ ] First nightly run after merge: check run log for `stats:` lines and the report's Total-turns jump (expected, documented in the self-audit prompt)

## Test plan

- [x] `tests/run-all.sh`: 89/89 — includes the five spec acceptance fixtures (tool_result carriers, sparse fractional timestamps, pasted RETRY-BUDGET strings, text+image turn, sidechain shape)
- [x] `test_framing` extended: stats block position asserted after the doc body; line-1/2 framing unchanged
- [x] `bash -n` on run.sh and session-stats.sh
- [x] Real transcript spot check against hand counts

https://claude.ai/code/session_015GnTbqJQNHLqYC8rx67UYG
