### PR TITLE
feat: multi-clauding overlap stat via global sidecar pass (#14)

### DIFF
--- a/bin/overlap-stats.sh
+++ b/bin/overlap-stats.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Deterministic, model-free global overlap pass for cc-autodream (GitHub issue #14).
+#
+# Cross-session computation: given a findings directory already populated with
+# per-session *.stats.json sidecars (written by session-stats.sh's user_turn_timestamps
+# field), compute how many distinct session pairs had a user turn within 30 minutes of
+# each other ("multi-clauding" — the same human working two sessions concurrently).
+#
+# Definition (issue #14, unit pinned to seconds):
+#   overlap_events        = number of DISTINCT unordered session-id pairs {A,B} such
+#                            that some user turn of A and some user turn of B occur
+#                            within WINDOW_SECONDS of each other. Pair-set semantics:
+#                            a pair counts ONCE no matter how many turn-pairs qualify.
+#   sessions_with_overlap = number of distinct session ids appearing in at least one
+#                            such pair.
+#
+# Session identity: the sidecar's filename stem, i.e. the 12-char sha1 hash of the
+# session path that run.sh already uses as the findings-file key (see hash_of /
+# compute_session_stats in bin/run.sh). Stable per session, no need to re-derive it
+# from session_path.
+#
+# Gating note: run.sh's noise gate (#7) decides per-session whether to skip the L1
+# model call, but it runs AFTER compute_session_stats has already written every
+# session's *.stats.json sidecar. Gated sessions' sidecars still exist and still carry
+# user_turn_timestamps, so they STILL participate in overlap here — this stat measures
+# concurrent human activity, not triage-worthiness, and this script has no visibility
+# into (and does not care about) the gate decision.
+#
+# Usage: overlap-stats.sh <findings_dir> [window_seconds]   (default window: 1800 = 30 min)
+# Prints a single-line JSON object {"overlap_events":N,"sessions_with_overlap":N} to
+# stdout. Never fails the caller: an empty/missing findings dir yields 0/0.
+
+set -u
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  echo "usage: $0 <findings_dir> [window_seconds]" >&2
+  exit 2
+fi
+
+findings_dir="$1"
+window="${2:-1800}"
+
+if [ ! -d "$findings_dir" ]; then
+  printf '{"overlap_events":0,"sessions_with_overlap":0}\n'
+  exit 0
+fi
+
+# NDJSON: one {"id":..., "ts":[...]} line per sidecar. Missing/empty user_turn_timestamps
+# (pre-#14 sidecars, or sessions with no timestamped user turns) become [] and simply
+# can't form a pair — jq's has_overlap already short-circuits on an empty array.
+build_session_list() {
+  local f id
+  for f in "$findings_dir"/*.stats.json; do
+    [ -e "$f" ] || continue
+    id=$(basename "$f" .stats.json)
+    jq -c --arg id "$id" '{id: $id, ts: (.user_turn_timestamps // [])}' "$f" 2>/dev/null
+  done
+}
+
+build_session_list | jq -s --argjson w "$window" '
+  # Two-pointer sweep over two sorted epoch-second arrays: true iff some pair is
+  # within $w seconds of each other. O(|a| + |b|) — deliberately not a cross product,
+  # since a long session can carry hundreds of user-turn timestamps.
+  def has_overlap($a; $b; $w):
+    ($a | length) as $la | ($b | length) as $lb
+    | if $la == 0 or $lb == 0 then false
+      else
+        { i: 0, j: 0, found: false }
+        | until(
+            .found or (.i >= $la) or (.j >= $lb);
+            ($a[.i]) as $x | ($b[.j]) as $y
+            | (($x - $y) | if . < 0 then -. else . end) as $d
+            | if $d <= $w then .found = true
+              elif $x < $y then .i += 1
+              else .j += 1
+              end
+          )
+        | .found
+      end;
+
+  [ .[] | select((.ts | length) > 0) ] as $sessions
+  | ($sessions | length) as $n
+  | reduce range(0; $n) as $i (
+      { events: 0, involved: {} };
+      reduce range($i + 1; $n) as $j (
+        .;
+        if has_overlap($sessions[$i].ts; $sessions[$j].ts; $w)
+        then
+          .events += 1
+          | .involved[$sessions[$i].id] = true
+          | .involved[$sessions[$j].id] = true
+        else . end
+      )
+    )
+  | { overlap_events: .events, sessions_with_overlap: (.involved | keys | length) }
+'

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -69,6 +69,9 @@ SLIM="$SCRIPT_DIR/slim-transcript.sh"
 # Deterministic session-stat pre-pass (resolved like the other helper scripts).
 STATS="$SCRIPT_DIR/session-stats.sh"
 [ -x "$STATS" ] || STATS="$AUTODREAM_DIR/session-stats.sh"
+# Global cross-session overlap pass (#14; resolved like the other helper scripts).
+OVERLAP="$SCRIPT_DIR/overlap-stats.sh"
+[ -x "$OVERLAP" ] || OVERLAP="$AUTODREAM_DIR/overlap-stats.sh"
 
 mkdir -p "$FINDINGS_DIR" "$DREAMS_DIR" "$LOG_DIR" "$WORK_DIR"
 
@@ -225,6 +228,31 @@ compute_session_stats() {
       echo "stats failed: $session ($hash); continuing without precomputed stats" >&2
     fi
   done < "$SESSIONS_LIST"
+}
+
+# ---- Global overlap pass (#14): cross-session "multi-clauding" stat ----
+# Runs once compute_session_stats has written every session's *.stats.json sidecar
+# (each carries the mechanical user_turn_timestamps array). Overlap is a GLOBAL,
+# cross-session computation — it can't be done per-session inside compute_session_stats
+# or dispatch_l1's xargs subshells, which only ever see one session at a time. Sets
+# OVERLAP_EVENTS / SESSIONS_WITH_OVERLAP (default "0"/"0" on any failure/absence so the
+# run-stats.txt writer always has a value, never aborts the pipeline).
+compute_overlap_stats() {
+  OVERLAP_EVENTS=0
+  SESSIONS_WITH_OVERLAP=0
+  if [ ! -x "$OVERLAP" ]; then
+    log "overlap-stats.sh not found/executable; skipping overlap computation (0/0)"
+    return 0
+  fi
+  local json events involved
+  json=$("$OVERLAP" "$FINDINGS_DIR" 2>>"$RUN_LOG")
+  if [ -n "$json" ]; then
+    events=$(printf '%s' "$json" | jq -r '.overlap_events // 0' 2>/dev/null)
+    involved=$(printf '%s' "$json" | jq -r '.sessions_with_overlap // 0' 2>/dev/null)
+    [ -n "$events" ] && OVERLAP_EVENTS="$events"
+    [ -n "$involved" ] && SESSIONS_WITH_OVERLAP="$involved"
+  fi
+  log "overlap: $OVERLAP_EVENTS pair(s), $SESSIONS_WITH_OVERLAP session(s) involved"
 }
 
 dispatch_l1() { # one parallel pass; idempotent worker → only the still-missing sessions run
@@ -422,6 +450,12 @@ EOF
   # they are intentionally not regenerated during dispatch retries.
   compute_session_stats
 
+  # Global pass: must run AFTER every session's sidecar exists (overlap is a
+  # cross-session computation, not per-session). Deliberately BEFORE the noise gate
+  # runs inside dispatch_l1 below — gated sessions' sidecars still exist and still
+  # participate in overlap (see the comment in bin/overlap-stats.sh).
+  compute_overlap_stats
+
   # ---- Layer 1: haiku triage, parallel, retried across sleep/network gaps ----
   # Lean-query env (claude-cells internal/claude/query.go pattern): keep subscription
   # OAuth auth but strip per-call bloat — no CLAUDE.md auto-load, no telemetry/error
@@ -562,6 +596,9 @@ PY
     printf 'l1_sessions_already_done_at_start: %s\n' "$L1_PRECACHED"
     printf 'l1_sessions_freshly_processed: %s\n' "$L1_FRESHLY_PROCESSED"
     printf 'l1_elapsed_seconds: %s\n' "$L1_ELAPSED"
+    # Global cross-session overlap stat (#14) — see compute_overlap_stats above.
+    printf 'overlap_events: %s\n' "$OVERLAP_EVENTS"
+    printf 'sessions_with_overlap: %s\n' "$SESSIONS_WITH_OVERLAP"
   } > "$FINDINGS_DIR/run-stats.txt"
 
   # ---- Upstream changelog window (writes changelog-window.md for L2 to read) ----

--- a/bin/session-stats.sh
+++ b/bin/session-stats.sh
@@ -46,6 +46,24 @@ jq -R -s \
           )
         )
     ] as $user_messages
+  | (
+      [
+        $lines[]
+        | select(.type == "user" and .isMeta != true)
+        | select(
+            (.message.content) as $c
+            | ($c | type) == "string"
+            or (
+              ($c | type) == "array"
+              and any($c[]?; .type == "text")
+              and all($c[]?; .type != "tool_result")
+            )
+          )
+        | .timestamp
+        | select(type == "string")
+        | try (sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601) catch empty
+      ] | sort
+    ) as $user_turn_timestamps
   | [
       $lines[]
       | select(.isMeta != true and (.type == "user" or .type == "assistant"))
@@ -100,6 +118,7 @@ jq -R -s \
       },
       transcript_bytes: $transcript_bytes,
       transcript_mtime: $transcript_mtime,
-      isSidechain: (any($lines[]?; .isSidechain == true))
+      isSidechain: (any($lines[]?; .isSidechain == true)),
+      user_turn_timestamps: $user_turn_timestamps
     }
   ' "$transcript" > "$output"

--- a/install.sh
+++ b/install.sh
@@ -48,6 +48,7 @@ link "$REPO_DIR/bin/make-notifier.sh"   "$TARGET/make-notifier.sh"
 link "$REPO_DIR/bin/prune-self-sessions.sh" "$TARGET/prune-self-sessions.sh"
 link "$REPO_DIR/bin/slim-transcript.sh"     "$TARGET/slim-transcript.sh"
 link "$REPO_DIR/bin/session-stats.sh"        "$TARGET/session-stats.sh"
+link "$REPO_DIR/bin/overlap-stats.sh"        "$TARGET/overlap-stats.sh"
 link "$REPO_DIR/prompts/PROMPT.md"      "$TARGET/PROMPT.md"
 link "$REPO_DIR/prompts/SESSION_TRIAGE.md" "$TARGET/SESSION_TRIAGE.md"
 

--- a/prompts/PROMPT.md
+++ b/prompts/PROMPT.md
@@ -40,6 +40,7 @@ Write to `REPORT_PATH`. Overwrite if present (idempotent re-runs are fine). Requ
 - Skills invoked (top 5 by count)
 - Models used (with counts)
 - Outcomes: distribution of the per-session `outcome` facet when present (e.g. "18 sessions with outcome: 12 fully, 3 mostly, 1 partial, 2 unclear"), plus any non-zero `satisfaction_signals` totals summed across sessions. Omit the line if no JSON carries the facet fields (pre-pilot findings). This line is descriptive only — it does NOT change the Top-patterns ranking formula.
+- Multi-clauding: read `<findings-dir>/run-stats.txt`'s `overlap_events` and `sessions_with_overlap` fields — how many sessions had a user turn within 30 minutes of a user turn in a *different* session that day (concurrent human activity across sessions, not a quality signal). When either field is present and greater than 0, add a line like "Multi-clauding: 3 sessions overlapped in 2 pairs." Omit the line entirely when both fields are 0, or when the keys are absent (findings dirs predating #14).
 
 ## Upstream Claude Code changes
 Read `<findings-dir>/changelog-window.md` (the runner's diff of `anthropics/claude-code`'s `CHANGELOG.md` over this report's date window). For each release entry in it, judge whether it changes how we should operate:

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -69,6 +69,15 @@ mk_subagent_session(){ # $1=root $2=name — isSidechain + >=5 tool calls: carve
     > "$f"
   touch -t "$STAMP" "$f"
 }
+mk_timed_session(){ # $1=root $2=name $3.. = ISO8601 timestamps, one user turn each (#14 overlap fixtures)
+  local root="$1" name="$2"; shift 2
+  local f="$root/projects/proj-a/$name.jsonl" ts
+  : > "$f"
+  for ts in "$@"; do
+    printf '{"type":"user","timestamp":"%s","message":{"content":"turn"}}\n' "$ts" >> "$f"
+  done
+  touch -t "$STAMP" "$f"
+}
 hash_of(){ printf '%s' "$1" | shasum -a 1 | cut -c1-12; }
 run_dream(){ # $1=root ; inherits MOCK_MODE/MOCK_CAPTURE_DIR/FANOUT + changelog knobs from env
   # Changelog check defaults OFF so the suite never touches the network; the dedicated
@@ -97,8 +106,9 @@ test_session_stats(){
     '{"type":"user","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"b","content":"result"}]}}' > "$fixture"
   "$REPO/bin/session-stats.sh" "$fixture" "$out"
   assert_eq "$(jq -r 'keys | sort | join(",")' "$out")" \
-    "compliance_markers,duration_minutes,isSidechain,models_used,tool_call_count,tools_used,transcript_bytes,transcript_mtime,turn_count,user_message_count" \
+    "compliance_markers,duration_minutes,isSidechain,models_used,tool_call_count,tools_used,transcript_bytes,transcript_mtime,turn_count,user_message_count,user_turn_timestamps" \
     "stats output has exactly the specified fields"
+  assert_eq "$(jq -r '.user_turn_timestamps | length' "$out")" "0" "no timestamped user turns in this fixture -> empty user_turn_timestamps"
   assert_eq "$(jq -r .user_message_count "$out")" "1" "tool_result carriers are excluded from user message count"
   assert_eq "$(jq -r .turn_count "$out")" "4" "turn count includes tool_result carriers"
 
@@ -112,6 +122,7 @@ test_session_stats(){
   "$REPO/bin/session-stats.sh" "$fixture" "$out"
   assert_eq "$(jq -r .duration_minutes "$out")" "2.5" "duration uses available fractional timestamps"
   assert_eq "$(jq -r .models_used[0] "$out")" "claude-opus" "synthetic model is dropped"
+  assert_eq "$(jq -r '.user_turn_timestamps | join(",")' "$out")" "1784541600" "user_turn_timestamps holds only the (fractional-second-truncated) real user turn's epoch"
 
   fixture="$root/markers.jsonl"; out="$root/markers.stats.json"
   printf '%s\n' \
@@ -541,6 +552,47 @@ test_noise_gate_env_override(){
   rm -rf "$root"
 }
 
+test_overlap_pair(){
+  echo "# overlap (#14): two alternating-close sessions count as ONE pair regardless of qualifying turn-pairs"
+  local root; root=$(setup_env)
+  # A: 10:00, 10:20   B: 10:05, 10:25 — every A/B turn combo is within 30 min
+  # (A0-B0=5m, A0-B1=25m, A1-B0=15m, A1-B1=5m), so four turn-pairs qualify but
+  # the {A,B} pair must be counted exactly once.
+  mk_timed_session "$root" sessA "2026-07-20T10:00:00Z" "2026-07-20T10:20:00Z"
+  mk_timed_session "$root" sessB "2026-07-20T10:05:00Z" "2026-07-20T10:25:00Z"
+  run_dream "$root"
+  local stats="$(fdir "$root")/run-stats.txt"
+  assert_grep "$stats" 'overlap_events: 1'         "exactly one distinct pair counted"
+  assert_grep "$stats" 'sessions_with_overlap: 2'  "both sessions counted as involved"
+  rm -rf "$root"
+}
+
+test_overlap_triple(){
+  echo "# overlap (#14): three pairwise-overlapping sessions -> 3 pairs, 3 sessions"
+  local root; root=$(setup_env)
+  # A@10:00, B@10:10, C@10:20 — every pair (A-B=10m, B-C=10m, A-C=20m) is within 30 min.
+  mk_timed_session "$root" sessA "2026-07-20T10:00:00Z"
+  mk_timed_session "$root" sessB "2026-07-20T10:10:00Z"
+  mk_timed_session "$root" sessC "2026-07-20T10:20:00Z"
+  run_dream "$root"
+  local stats="$(fdir "$root")/run-stats.txt"
+  assert_grep "$stats" 'overlap_events: 3'         "all three pairs counted"
+  assert_grep "$stats" 'sessions_with_overlap: 3'  "all three sessions counted as involved"
+  rm -rf "$root"
+}
+
+test_overlap_none(){
+  echo "# overlap (#14): sessions more than 30 minutes apart -> both stats 0, keys still present"
+  local root; root=$(setup_env)
+  mk_timed_session "$root" sessA "2026-07-20T10:00:00Z"
+  mk_timed_session "$root" sessB "2026-07-20T11:00:00Z"
+  run_dream "$root"
+  local stats="$(fdir "$root")/run-stats.txt"
+  assert_grep "$stats" 'overlap_events: 0'         "no pairs when sessions are far apart"
+  assert_grep "$stats" 'sessions_with_overlap: 0'  "no sessions involved when sessions are far apart"
+  rm -rf "$root"
+}
+
 # ---------------------------------------------------------------------------
 
 [ -x "$RUN" ]  || { echo "FATAL: $RUN not executable"; exit 1; }
@@ -574,6 +626,9 @@ test_noise_gate_short_duration
 test_noise_gate_subagent_carveout
 test_noise_gate_stats
 test_noise_gate_env_override
+test_overlap_pair
+test_overlap_triple
+test_overlap_none
 echo
 echo "----------------------------------------"
 echo "passed: $pass   failed: $fail"


### PR DESCRIPTION
## Summary

Phase 2 of the /insights-parity epic: closes #14. Sidecars gain an additive `user_turn_timestamps` array; new `bin/overlap-stats.sh` runs a global cross-session pass computing the pinned pair-set stats (`overlap_events` = distinct session pairs with user turns within 30 min, counted once per pair; `sessions_with_overlap` = distinct involved sessions). Two additive run-stats keys; one conditional Activity-snapshot line. Gated sessions still participate — the stat measures concurrent human activity, not triage-worthiness.

## Status — 2026-07-20

| item | state | evidence |
|---|---|---|
| Implementation | done | 761d6c4 (sonnet subagent; orchestrator reviewed the pair-scan jq and run.sh wiring) |
| Review fix during verify | applied | install.sh symlink line for the new script (same gap #6 hit) |
| Tests | passing | 111/111 (3 acceptance fixtures incl. the pair-set-semantics case); review-skip 23/23 |
| CodeRabbit / CI | absent | local review is the gate |

## Test plan

- [x] Alternating close turns: overlap_events=1, sessions_with_overlap=2 (pair counted once)
- [x] Three pairwise-overlapping sessions: 3 / 3
- [x] >30 min apart: 0 / 0 with keys present
- [x] Full suites green

https://claude.ai/code/session_015GnTbqJQNHLqYC8rx67UYG