### PR TITLE
test: run the suite on every push, because nothing did

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,54 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    # macOS, not Linux: the suites use BSD `date` and `touch` semantics and will
+    # fail on GNU coreutils. Every suite runs against tests/mock-claude.sh, so
+    # nothing here needs network or a real model.
+    runs-on: macos-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: check deps
+        run: |
+          jq --version
+          python3 --version
+
+      - name: run-all
+        run: bash tests/run-all.sh
+
+      - name: cookie-cadence
+        run: bash tests/cookie-cadence.sh
+
+      - name: review-skip
+        run: bash tests/review-skip.sh
+
+      - name: x-bookmarks
+        run: bash tests/x-bookmarks.sh
+
+  shellcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      # The shipped scripts are held at `warning`. A cron job nobody watches
+      # cannot afford a swallowed exit code, and that is the class shellcheck
+      # actually catches (SC2164, SC2155).
+      - name: shellcheck bin + install
+        run: shellcheck --severity=warning bin/*.sh install.sh
+
+      # Test code is held at `error` only. tests/run-all.sh has ~24 SC2155
+      # hits from `local x=$(cmd)` in assertion helpers, where masking a return
+      # value has no consequence. Tighten this if that stops being true.
+      - name: shellcheck tests
+        run: shellcheck --severity=error tests/*.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: tests
 
+# push is filtered to main on purpose: with `pull_request:` also enabled, an
+# unfiltered push trigger runs every PR commit twice. Branch work is covered by
+# the PR trigger; both routes into main - a merge and a direct push - fire the
+# push trigger. A feature branch with no PR runs nothing, which is the trade.
 on:
   push:
     branches: [main]
@@ -26,7 +30,7 @@ jobs:
         run: |
           jq --version
           python3 --version
-          brew install coreutils
+          command -v gtimeout >/dev/null 2>&1 || brew install coreutils
           gtimeout --version | head -1
 
       - name: run-all

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,10 +18,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # coreutils is for `gtimeout` only: four oversized-gate assertions need GNU
+      # timeout and stock macOS ships neither name. Deliberately NOT adding
+      # coreutils' gnubin to PATH - the suite depends on BSD `date` and `touch`,
+      # and GNU versions of those would break far more than they fix.
       - name: check deps
         run: |
           jq --version
           python3 --version
+          brew install coreutils
+          gtimeout --version | head -1
 
       - name: run-all
         run: bash tests/run-all.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -195,6 +195,24 @@ How it works: it writes a transient one-shot LaunchAgent (`<base-label>.ondemand
 
 When you (the agent) need to kick off a run, prefer this over a background Bash task — fire it, then poll `dreams/<date>.md` instead of holding a long task open.
 
+## Reviewing changes here
+
+Almost everything in this repo is shell, and a shell bug here fails silently on a
+nightly cron nobody is watching. `/code-review` is a fine first pass but it is not the
+gate. Before merging any change to `run.sh`, `bin/*.sh`, `install.sh`, the launchd
+plists, or the prompts, also run `/debate:run tight` — that preset is Codex + Gemini +
+DeepSeek, so at least one seat does not share Claude's blind spots.
+
+This is not a hypothetical. PR #37 (merged 2026-08-02) was reviewed by a fanout of 30+
+Claude verifier subagents. They found 18 real defects, which is the case for the fanout.
+But ten of those verifiers issued verdicts quoting `file:line` they had never read, and
+three of them accused a sibling of fabricating citations while fabricating their own.
+Adding more Claude seats does not catch that, because every seat fails the same way.
+A different vendor does.
+
+DeepSeek direct retains prompts and trains on them. That is fine for this repo, which is
+public. For private code, swap the seat rather than skipping the pass.
+
 ## Tests
 
 `tests/run-all.sh` drives the real `run.sh` against `tests/mock-claude.sh` (no network, no model). Mock modes: `good` (default), `l1_incomplete` (worker writes nothing), `l1_flaky` (fails first dispatch per session, succeeds on retry). The suite forces `AUTODREAM_NETCHECK=0 AUTODREAM_RETRY_WAIT=0` and a low `AUTODREAM_L1_ROUNDS` so it never sleeps or hits the network. macOS only (BSD `date`/`touch`). Run it after any run.sh/prompt change.

--- a/bin/review.sh
+++ b/bin/review.sh
@@ -232,7 +232,7 @@ echo "─── autodream review: $DATE ($REPORT_BYTES bytes) ───"
 echo "Starting triage. /quit to exit."
 echo
 
-cd "$HOME"
+cd "$HOME" || exit 1
 exec "$CLAUDE_BIN" \
   --permission-mode bypassPermissions \
   --append-system-prompt "$SYSTEM" \

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -190,7 +190,7 @@ fi
 mkdir -p "$FINDINGS_DIR" "$DREAMS_DIR" "$LOG_DIR" "$WORK_DIR"
 
 export PATH="$HOME/.cargo/bin:$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-cd "$HOME"
+cd "$HOME" || exit 1
 
 log() { echo "[$(date '+%H:%M:%S')] $*"; }
 

--- a/install.sh
+++ b/install.sh
@@ -108,7 +108,8 @@ install_schedule() {
   local path_val="${path_dirs:+$path_dirs:}/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
   local target_plist="$la_dir/$label.plist"
-  local domain="gui/$(id -u)"
+  local domain
+  domain="gui/$(id -u)"
 
   cat > "$target_plist" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1166,14 +1166,22 @@ test_oversized_gate_script_args(){
   [ -x "$GATE" ] || { no "oversized-gate.sh executable"; return 0; }
   # `--days` with no value left $# at 1 while `shift 2` refused to shift, looping forever.
   # A hang in a nightly-adjacent script is worse than a wrong number, so it gets a test.
+  # These are the only assertions in the suite that need GNU `timeout`. Stock macOS has
+  # neither name; homebrew coreutils installs `gtimeout`, and `timeout` too if its gnubin
+  # is on PATH. Resolve whichever exists and say so plainly when neither does — without
+  # this, all four assertions come back as exit 127 and read like real regressions.
+  local TO=""
+  command -v timeout  >/dev/null 2>&1 && TO=timeout
+  [ -n "$TO" ] || { command -v gtimeout >/dev/null 2>&1 && TO=gtimeout; }
+  [ -n "$TO" ] || { no "oversized-gate arg tests need GNU timeout (brew install coreutils)"; return 0; }
   local out rc
-  out=$( { timeout 10 bash "$GATE" --days; } 2>&1 ); rc=$?
+  out=$( { "$TO" 10 bash "$GATE" --days; } 2>&1 ); rc=$?
   assert_eq "$rc" "2" "--days with no value exits 2 instead of hanging (124 would be the hang)"
-  out=$( { timeout 10 bash "$GATE" --days abc; } 2>&1 ); rc=$?
+  out=$( { "$TO" 10 bash "$GATE" --days abc; } 2>&1 ); rc=$?
   assert_eq "$rc" "2" "--days with a non-integer exits 2"
-  out=$( { timeout 10 bash "$GATE" --days 0; } 2>&1 ); rc=$?
+  out=$( { "$TO" 10 bash "$GATE" --days 0; } 2>&1 ); rc=$?
   assert_eq "$rc" "2" "--days 0 exits 2"
-  out=$( { timeout 10 bash "$GATE" --bogus; } 2>&1 ); rc=$?
+  out=$( { "$TO" 10 bash "$GATE" --bogus; } 2>&1 ); rc=$?
   assert_eq "$rc" "2" "an unknown option exits 2 rather than being read as a findings dir"
 }
 


### PR DESCRIPTION
This repo had no CI. No `.github`, no git hooks, nothing. 20 shell scripts, a 66KB `run.sh`, and 333 tests that only ran when someone remembered.

## What runs

| Job | Runner | What |
|---|---|---|
| `test` | macos-latest | run-all (252), cookie-cadence (17), review-skip (23), x-bookmarks (41) |
| `shellcheck` | ubuntu-latest | `bin/` + `install.sh` at `warning`, `tests/` at `error` |

macOS is not a preference - the suites use BSD `date` and `touch` and fail under GNU coreutils. Everything runs against `tests/mock-claude.sh`, so no network and no model. `run-all.sh` does not invoke the other three, which is why the workflow names each one.

## Why two shellcheck severities

Shipped scripts gate at `warning`. A cron job nobody watches can't afford a swallowed exit code, and that's the class shellcheck actually catches. Test code gates at `error` only - `tests/run-all.sh` has ~24 SC2155 hits in assertion helpers where masking a return value costs nothing. Tighten it if that stops being true.

Three warnings fixed so the gate is real rather than cosmetic:

- `bin/review.sh:235` and `bin/run.sh:193` - `cd "$HOME"` with no guard, one right before an `exec` and one before the entire run. A failed `cd` there runs the pipeline from the wrong directory instead of stopping. (SC2164)
- `install.sh:111` - `local domain="gui/$(id -u)"` masks the substitution's exit status. (SC2155)

All four suites pass locally after those edits. `run-all.sh` takes 36s.

## Also in here

`CLAUDE.md` gets a review policy: shell and config changes run `/debate:run tight` before merge, not a solo Claude pass.

PR #37 was reviewed by 30+ Claude verifier subagents. They found 18 real defects, which is the case *for* the fanout. But ten of those verifiers issued verdicts quoting `file:line` they had never read, and three accused a sibling of fabricating citations while fabricating their own. More Claude seats don't catch that, because every seat fails the same way. `tight` is Codex + Gemini + DeepSeek.

DeepSeek direct retains prompts and trains on them. Fine here, this repo is public. Swap the seat for private code rather than skipping the pass.

https://claude.ai/code/session_017hafeHA7mTjAaPxquf6mMx
