### PR TITLE
fix: resolve the runner's own symlink so provenance names a real commit

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -169,19 +169,57 @@ else
 fi
 
 # Provenance of the code actually executing (#29), stamped into run-stats.txt below.
-# Resolved against SCRIPT_DIR (which follows the ~/.claude/autodream symlink back into
-# the working tree) rather than $PWD, since launchd starts the job from an unrelated cwd.
+# Resolved by walking this script's own symlink chain rather than by reusing SCRIPT_DIR,
+# which is a working directory and not a checkout. install.sh symlinks each script
+# individually into ~/.claude/autodream, so that directory is real and has no .git, and
+# `cd "$(dirname "$0")"` resolves symlinked *directories* but not a symlinked *file* —
+# it lands in the install dir every time. Six of the eight runs through 2026-08-03 wrote
+# `runner_commit: unknown` for that reason alone, which is the exact blind spot #29
+# existed to close. The two that did stamp a sha were launched from the repo by hand.
+# SCRIPT_DIR stays as it is: helper lookup genuinely wants the install dir.
 # Everything degrades to "unknown"/"no": a tarball install with no git, or no git binary
 # at all, is a supported way to run this and must not fail the run.
 # --untracked-files=no on the dirty check: "dirty" is meant to warn that the run used code
 # that exists in nobody's history, which only tracked modifications can cause. Counting
 # untracked files made the first production run report runner_dirty: yes over a stray
 # scratch directory, which is exactly the kind of false alarm that gets a signal ignored.
-RUNNER_COMMIT=$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null) || RUNNER_COMMIT=""
+RUNNER_SRC="${BASH_SOURCE[0]}"
+runner_hops=0
+# A symlink can point at another symlink, and a target can be relative to the link's own
+# directory rather than to $PWD. The hop cap keeps a cycle from hanging the run.
+# 8 rather than a bigger round number so the cap is reachable in a test: macOS refuses to
+# execute anything behind 16+ links (ELOOP), so a cap at or above that could never fire on
+# a script that got far enough to run this code, and an untestable guard is a guess. Linux
+# allows 40, where it can genuinely fire. A real install is one hop.
+while [ -L "$RUNNER_SRC" ] && [ "$runner_hops" -lt 8 ]; do
+  runner_link_dir=$(cd "$(dirname "$RUNNER_SRC")" && pwd) || break
+  RUNNER_SRC=$(readlink "$RUNNER_SRC") || break
+  case $RUNNER_SRC in /*) ;; *) RUNNER_SRC="$runner_link_dir/$RUNNER_SRC" ;; esac
+  runner_hops=$((runner_hops + 1))
+done
+# Still a symlink means the walk gave up (a cycle, or a chain past the cap) rather than
+# arriving anywhere. Resolving the truncated path would stamp whatever checkout it happens
+# to sit in, and a confidently wrong sha is worse than no sha at all — the whole point of
+# #29 is that this field can be trusted when someone is chasing a bad night.
+if [ -L "$RUNNER_SRC" ]; then
+  RUNNER_REPO_DIR=""
+else
+  RUNNER_REPO_DIR=$(cd "$(dirname "$RUNNER_SRC")" && pwd) || RUNNER_REPO_DIR=""
+fi
+# The empty case has to short-circuit before git rather than lean on git to reject it:
+# `git -C "" rev-parse HEAD` does NOT fail, it silently stays in $PWD and answers for
+# whatever repo the caller happened to launch from. launchd starts this job from an
+# unrelated cwd, so leaving that to git would stamp a stranger's sha and call it
+# provenance.
+if [ -z "$RUNNER_REPO_DIR" ]; then
+  RUNNER_COMMIT=""
+else
+  RUNNER_COMMIT=$(git -C "$RUNNER_REPO_DIR" rev-parse --short HEAD 2>/dev/null) || RUNNER_COMMIT=""
+fi
 : "${RUNNER_COMMIT:=unknown}"
 if [ "$RUNNER_COMMIT" = "unknown" ]; then
   RUNNER_DIRTY=no
-elif [ -n "$(git -C "$SCRIPT_DIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
+elif [ -n "$(git -C "$RUNNER_REPO_DIR" status --porcelain --untracked-files=no 2>/dev/null)" ]; then
   RUNNER_DIRTY=yes
 else
   RUNNER_DIRTY=no

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -1112,6 +1112,81 @@ test_runner_provenance_no_git(){
   rm -rf "$root"
 }
 
+test_runner_provenance_through_symlink(){
+  echo "# runner provenance (#29): the installed symlink layout still stamps the repo's sha"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  # Reproduce what install.sh actually leaves on disk, which is what the earlier tests
+  # missed: ~/.claude/autodream is a REAL directory holding one symlink per script, not a
+  # symlink to the checkout. `cd "$(dirname "$0")"` therefore lands in a directory with no
+  # .git, and provenance has to follow the file's own link to find the working tree.
+  # Six production runs through 2026-08-03 stamped "unknown" against a clean checkout.
+  local f; for f in "$REPO"/bin/*.sh; do ln -sf "$f" "$root/autodream/$(basename "$f")"; done
+  AUTODREAM_GC=0 AUTODREAM_CHANGELOG=0 CLAUDE_BIN="$MOCK" \
+  AUTODREAM_CONFIG="$root/autodream/config" AUTODREAM_CONSUME_DATE="$DATE" \
+  AUTODREAM_NETCHECK=0 AUTODREAM_RETRY_WAIT=0 AUTODREAM_L1_ROUNDS=2 \
+  PROJECTS_DIR="$root/projects" AUTODREAM_DIR="$root/autodream" DREAMS_DIR="$root/dreams" \
+  bash "$root/autodream/run.sh" "$DATE" > "$root/run.out" 2>&1
+  local head; head=$(git -C "$REPO" rev-parse --short HEAD 2>/dev/null)
+  local stats="$(fdir "$root")/run-stats.txt"
+  assert_grep "$stats" "runner_commit: $head" "a symlinked runner reports the checkout it points at"
+  assert_file "$root/dreams/$DATE.md"          "the run still produced a report"
+  rm -rf "$root"
+}
+
+test_runner_provenance_relative_symlink(){
+  echo "# runner provenance (#29): a symlink with a relative target still finds the checkout"
+  command -v python3 >/dev/null 2>&1 || { echo "  skip - python3 not available"; return 0; }
+  local root; root=$(setup_env); mk_session "$root" sess1
+  # install.sh writes absolute targets, so nothing in production exercises the walk's
+  # relative-target branch. A hand-rolled install (ln -s ../../git/oss/cc-autodream/bin/…)
+  # produces one, and a target resolved against $PWD instead of the link's own directory
+  # silently lands nowhere.
+  # Both sides must be physical paths before relpath: on macOS $TMPDIR sits under /var,
+  # which is itself a link to /private/var, so a relative path computed from the logical
+  # name walks up through a directory that does not exist and the link is born broken.
+  local phys_ad phys_bin rel
+  phys_ad=$(cd "$root/autodream" && pwd -P)
+  phys_bin=$(cd "$REPO/bin" && pwd -P)
+  rel=$(python3 -c 'import os,sys;print(os.path.relpath(sys.argv[1],sys.argv[2]))' "$phys_bin" "$phys_ad")
+  local f; for f in "$REPO"/bin/*.sh; do ln -sf "$rel/$(basename "$f")" "$root/autodream/$(basename "$f")"; done
+  AUTODREAM_GC=0 AUTODREAM_CHANGELOG=0 CLAUDE_BIN="$MOCK" \
+  AUTODREAM_CONFIG="$root/autodream/config" AUTODREAM_CONSUME_DATE="$DATE" \
+  AUTODREAM_NETCHECK=0 AUTODREAM_RETRY_WAIT=0 AUTODREAM_L1_ROUNDS=2 \
+  PROJECTS_DIR="$root/projects" AUTODREAM_DIR="$root/autodream" DREAMS_DIR="$root/dreams" \
+  bash "$root/autodream/run.sh" "$DATE" > "$root/run.out" 2>&1
+  local head; head=$(git -C "$REPO" rev-parse --short HEAD 2>/dev/null)
+  assert_grep "$(fdir "$root")/run-stats.txt" "runner_commit: $head" "a relative link target resolves against the link's own dir"
+  assert_file "$root/dreams/$DATE.md" "the run still produced a report"
+  rm -rf "$root"
+}
+
+test_runner_provenance_unresolvable_chain(){
+  echo "# runner provenance (#29): a chain past the hop cap says unknown, never a wrong sha"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  local f; for f in "$REPO"/bin/*.sh; do ln -sf "$f" "$root/autodream/$(basename "$f")"; done
+  # A chain longer than the cap leaves the walk holding a path that is still a symlink.
+  # Resolving it anyway would stamp the sha of whatever checkout that truncated path sits
+  # in — here, this very repo, which is exactly the plausible-but-wrong answer #29 exists
+  # to rule out. 12 hops clears the cap of 8 while staying under macOS's ELOOP limit of 16,
+  # so bash still executes the script and only the provenance field degrades.
+  local prev="$REPO/bin/run.sh" i
+  for i in $(seq 1 12); do
+    ln -sf "$prev" "$root/autodream/hop-$i.sh"
+    prev="$root/autodream/hop-$i.sh"
+  done
+  ln -sf "$prev" "$root/autodream/run.sh"
+  AUTODREAM_GC=0 AUTODREAM_CHANGELOG=0 CLAUDE_BIN="$MOCK" \
+  AUTODREAM_CONFIG="$root/autodream/config" AUTODREAM_CONSUME_DATE="$DATE" \
+  AUTODREAM_NETCHECK=0 AUTODREAM_RETRY_WAIT=0 AUTODREAM_L1_ROUNDS=2 \
+  PROJECTS_DIR="$root/projects" AUTODREAM_DIR="$root/autodream" DREAMS_DIR="$root/dreams" \
+  bash "$root/autodream/run.sh" "$DATE" > "$root/run.out" 2>&1
+  local stats="$(fdir "$root")/run-stats.txt"
+  assert_grep "$stats" 'runner_commit: unknown' "an unresolved chain degrades instead of guessing"
+  assert_grep "$stats" 'runner_dirty: no'       "dirty is not claimed when the commit is unknown"
+  assert_file "$root/dreams/$DATE.md"           "the run still produced a report"
+  rm -rf "$root"
+}
+
 test_oversized_gate_script(){
   echo "# oversized-gate.sh (#29): recomputes the #12 window from artifacts, including dates whose run-stats.txt lacks the keys"
   local GATE="$REPO/bin/oversized-gate.sh"
@@ -1574,6 +1649,9 @@ test_stats_sidecar_malformed_counted
 test_stats_sidecar_non_numeric_counted
 test_runner_provenance
 test_runner_provenance_no_git
+test_runner_provenance_through_symlink
+test_runner_provenance_relative_symlink
+test_runner_provenance_unresolvable_chain
 test_oversized_gate_script
 test_oversized_gate_script_open
 test_oversized_gate_script_empty


### PR DESCRIPTION
`runner_commit` has been blank since 2026-07-28. Six of the last eight nights stamped `unknown` against a clean checkout:

```
2026-07-26  48fa901   2026-07-31  unknown
2026-07-28  unknown   2026-08-01  894eb3f
2026-07-29  unknown   2026-08-02  unknown
2026-07-30  unknown   2026-08-03  unknown
```

That is the blind spot #29 was added to close. The two nights that got a sha were launched from the repo by hand, which is why this never showed up in testing.

## Cause

`install.sh` symlinks each script individually into `~/.claude/autodream`, so that directory is real and holds no `.git`. `cd "$(dirname "$0")"` resolves a symlinked *directory* but not a symlinked *file*, so `SCRIPT_DIR` landed in the install dir every night and `git -C` had nothing to answer with:

```
$ git -C ~/.claude/autodream rev-parse --short HEAD
fatal: not a git repository (or any of the parent directories): .git
```

The comment above the block claimed SCRIPT_DIR followed a symlink back into the working tree. That was true until the install layout moved to per-file links, and the comment outlived it.

## Fix

Provenance walks the script's own link chain. `SCRIPT_DIR` is unchanged, since helper lookup genuinely wants the install dir.

Two other ways this could go wrong, both handled:

An unresolved chain (a cycle, or one past the hop cap) leaves a path that is still a symlink. Resolving it anyway would stamp whatever checkout the truncated path sits in. A wrong sha is worse than no sha here, since the only reason to read this field is to trust it while chasing a bad night.

The empty case short-circuits before git rather than leaning on git to reject it. `git -C "" rev-parse HEAD` does not fail. It stays in `$PWD` and answers for whatever repo the caller launched from, and launchd starts this job from an unrelated cwd.

The hop cap is 8 rather than a larger round number so it is reachable in a test. macOS refuses to execute anything behind 16 or more links, so a cap at or above that could never fire on a script that got far enough to run this code. A real install is one hop.

## Tests

Three added, 259 passing, shellcheck clean.

- `test_runner_provenance_through_symlink` rebuilds the installed layout. It fails on the old code.
- `test_runner_provenance_relative_symlink` covers the relative-target branch, which `install.sh` never produces but a hand-rolled install does.
- `test_runner_provenance_unresolvable_chain` pins the degrade-to-unknown path at 12 hops, over the cap and under the kernel limit.

## Review

Gemini and DeepSeek seats of `/debate:run`, per this repo's CLAUDE.md. The Codex seats are quota-blocked until 2026-08-08.

DeepSeek caught the wrong-sha-on-cap-hit path. Checking its claim that the empty case already degraded safely is what turned up the `git -C ""` behavior, which nothing in the first draft handled.
