### PR TITLE
feat: AUTODREAM_L1_ONLY — stop after L1 so one aggregation can cover both harnesses

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -34,6 +34,8 @@
 #   AUTODREAM_FORCE      set 1 to rebuild even if a report exists    default: 0
 #   AUTODREAM_SLIM_BYTES sessions larger than this are slimmed for L1  default: 262144
 #   AUTODREAM_L2_MODEL   override the L2 aggregator model            default: fable-5 until 2026-06-20, claude-opus-4-7 from 2026-06-21
+#   AUTODREAM_L1_ONLY    set 1 to stop after L1: findings + run-stats are written, L2 is
+#                        skipped, nothing is consumed, exit 0                default: 0
 #   AUTODREAM_MIN_USER_TURNS  noise-gate floor on user_message_count  default: 2
 #   AUTODREAM_MIN_MINUTES     noise-gate floor on duration_minutes    default: 1
 #   AUTODREAM_STATS_BIN       override the resolved session-stats.sh path, authoritative
@@ -679,6 +681,10 @@ unassembled_dates() {
     # Findings JSONs only. A dir holding nothing but *.stats.json sidecars was never
     # triaged, so it has nothing to assemble and is not a failure.
     found=$(find "$d" -maxdepth 1 -type f -name '*.json' ! -name '*.stats.json' 2>/dev/null | head -1)
+    # An L1-only run leaves findings and no report on purpose, and says so with a marker.
+    # Without this the warning fires every night on a host that splits triage from
+    # aggregation, which is exactly the way to teach someone to ignore it.
+    [ -f "$d/l1-only" ] && continue
     [ -n "$found" ] || continue
     report="$DREAMS_DIR/$date_label.md"
     if [ -s "$report" ] && grep -q 'autodream:open-questions=' "$report" 2>/dev/null; then
@@ -1070,6 +1076,33 @@ PY
     [ -n "$XQID_SOURCE" ] || XQID_SOURCE=not_attempted
   fi
   printf 'x_queryid_source: %s\n' "$XQID_SOURCE" >> "$FINDINGS_DIR/run-stats.txt"
+
+  # ---- L1-only: stop here, deliberately, with everything L2 would need on disk ----
+  # For a host running one install per harness, the sane division is "each install
+  # triages its own sessions, ONE aggregation runs over the union" — otherwise every
+  # install pays for an L2 whose report nobody reads. This is the seam for that.
+  #
+  # Placed after the L2 *inputs* are assembled (findings, run-stats, changelog window,
+  # operator notes, bookmarks) and before anything that acts on a report: the findings dir
+  # is left as a complete aggregation package for whoever assembles it. And placed BEFORE
+  # the stale-report move below, which would otherwise rename a perfectly good report out
+  # of the way for a replacement this run is never going to write.
+  #
+  # Everything downstream that consumes input — the vault-notes archive, the x-bookmark
+  # mark-read, project-memory GC, the open-questions inbox — is gated on a complete report
+  # and is skipped by construction. The marker file says the omission was intentional, so
+  # the unassembled-dates scan does not report it as an abandoned date every night.
+  #
+  # AUTODREAM_L2_ATTEMPTS=0 is not a substitute: `seq 1 0` is empty, so L2 never runs, but
+  # the run then takes the no-report path — a WARNING, a non-zero exit, and a date that
+  # looks abandoned. Fine for a one-off experiment, wrong for a nightly.
+  if [ "${AUTODREAM_L1_ONLY:-0}" = "1" ]; then
+    : > "$FINDINGS_DIR/l1-only"
+    log "L1-only: findings ready at $FINDINGS_DIR; skipping L2, consuming nothing"
+    log "         assemble with: AUTODREAM_FORCE=1 $AUTODREAM_DIR/run.sh $TARGET_DATE"
+    log "===== autodream end: $(date) ====="
+    return 0
+  fi
 
   # ---- Layer 2: opus aggregate, retried until a report lands ----
   # The aggregator call can also die to a mid-run sleep (this is what left exit 1 +

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -94,6 +94,9 @@ run_dream(){ # $1=root ; inherits MOCK_MODE/MOCK_CAPTURE_DIR/FANOUT + changelog 
   AUTODREAM_NETCHECK=0 AUTODREAM_RETRY_WAIT=0 AUTODREAM_L1_ROUNDS="${AUTODREAM_L1_ROUNDS:-2}" \
   PROJECTS_DIR="$1/projects" AUTODREAM_DIR="$1/autodream" DREAMS_DIR="$1/dreams" \
   bash "$RUN" "$DATE" > "$1/run.out" 2>&1
+  # Exposed because "did this exit cleanly?" is itself a contract for some modes: an
+  # intentional early stop must not look like a failed run to launchd.
+  RUN_RC=$?
   # An unattended run logs to its file rather than through a pipe, so that stdout carries
   # only a pointer now. Fold the real log in, so every assertion below still reads what a
   # nightly run actually recorded rather than what a tty run happens to echo.
@@ -452,6 +455,78 @@ test_complete_report_retires_partials(){
   rm -rf "$root"
 }
 
+# ---- L1-only mode ----
+# For a host running two autodream installs (one per harness), the useful division is:
+# each install triages its own sessions, and ONE aggregation runs over the union. Without
+# a way to stop after L1 that costs an extra L2 per install, every night, for reports
+# nobody reads. AUTODREAM_L2_ATTEMPTS=0 almost does it (`seq 1 0` is empty) but then takes
+# the no-report path: warning logged, non-zero exit, and the date looks abandoned.
+test_l1_only_stops_after_findings(){
+  echo "# L1-only: findings land, no report, exit 0"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  local h; h=$(hash_of "$root/projects/proj-a/sess1.jsonl")
+  AUTODREAM_L1_ONLY=1 run_dream "$root"
+  assert_eq "$RUN_RC" "0" "an intentional stop is not a failure"
+  assert_file    "$(fdir "$root")/$h.json"      "the findings JSON is written"
+  assert_file    "$(fdir "$root")/run-stats.txt" "the self-audit is written"
+  assert_no_file "$root/dreams/$DATE.md"         "no report is produced"
+  assert_grep    "$root/run.out" 'L1-only' "the run says why it stopped"
+  rm -rf "$root"
+}
+
+test_l1_only_consumes_nothing(){
+  echo "# L1-only: no inbox file, no memory writes, nothing archived"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  # A note in the vault inbox is the sharpest probe: the consume gates live after L2, so
+  # returning early must leave it for the run that actually assembles a report.
+  local vault="$root/vault"; mkdir -p "$vault/inbox"
+  printf 'a note for the aggregator\n' > "$vault/inbox/note.md"
+  local mem="$root/projects/proj-a/memory/MEMORY.md"
+  mkdir -p "$(dirname "$mem")"; printf 'existing pin\n' > "$mem"
+  local before; before=$(shasum -a 1 < "$mem")
+  AUTODREAM_VAULT_DIR="$vault" MOCK_MODE=l2_memory_writer MOCK_MEMORY_FILE="$mem" \
+    AUTODREAM_L1_ONLY=1 run_dream "$root"
+  assert_file    "$vault/inbox/note.md" "the vault note stays in the inbox"
+  assert_eq      "$(shasum -a 1 < "$mem")" "$before" "project memory is untouched"
+  assert_no_file "$(fdir "$root")/touched-projects.txt" "no touched-projects sidecar"
+  assert_eq      "$(ls "$root/inbox" 2>/dev/null | wc -l | tr -d ' ')" "0" "no open-questions inbox file"
+  rm -rf "$root"
+}
+
+test_l1_only_date_is_not_reported_abandoned(){
+  echo "# L1-only: an intentionally unassembled date is not flagged as a failure"
+  local root; root=$(setup_env); mk_session "$root" s1
+  # A prior date left by an L1-only run: findings, no report, and the marker that says
+  # the omission was deliberate. Without the marker check this warning would fire every
+  # night on a host that splits triage from aggregation.
+  local prior="$root/autodream/findings/2020-01-01"
+  mkdir -p "$prior"
+  printf '{"session_path":"x","project":"proj-a","findings":[]}\n' > "$prior/aaaaaaaaaaaa.json"
+  : > "$prior/l1-only"
+  run_dream "$root"
+  assert_grep   "$(fdir "$root")/run-stats.txt" 'unassembled_dates: *$' "an L1-only date is not listed"
+  assert_nogrep "$root/run.out" 'findings but no complete report' "and no warning is logged"
+  # Control: the same findings dir WITHOUT the marker is still reported, so the marker is
+  # doing the work rather than the scan having been broken.
+  rm -f "$prior/l1-only" "$root/dreams/$DATE.md"
+  run_dream "$root"
+  assert_grep "$(fdir "$root")/run-stats.txt" 'unassembled_dates: 2020-01-01' "without the marker it is listed"
+  rm -rf "$root"
+}
+
+test_l1_only_then_assemble(){
+  echo "# L1-only: a later normal run assembles the same date without re-triaging"
+  local root; root=$(setup_env); mk_session "$root" sess1
+  AUTODREAM_L1_ONLY=1 run_dream "$root"
+  local h; h=$(hash_of "$root/projects/proj-a/sess1.jsonl")
+  export MOCK_CALL_LOG="$root/calls.txt"; run_dream "$root"; unset MOCK_CALL_LOG
+  assert_file "$root/dreams/$DATE.md" "the report lands on the assembling run"
+  # MOCK_CALL_LOG records one line per L1 invocation. L1 is idempotent, so the assembling
+  # run must spend no worker on an already-triaged session — that is the entire economic
+  # argument for splitting the phases.
+  assert_nogrep "$root/calls.txt" "$h" "no L1 worker ran for the already-triaged session"
+  rm -rf "$root"
+}
 test_no_sessions_stub_carries_marker(){
   echo "# the no-sessions stub is a complete report and must carry the marker"
   local root; root=$(setup_env)     # no sessions at all
@@ -1689,6 +1764,10 @@ test_complete_report_retires_partials
 test_dead_stdout_does_not_kill_the_run
 test_unassembled_dates_are_surfaced
 test_unassembled_ignores_a_finished_date
+test_l1_only_stops_after_findings
+test_l1_only_consumes_nothing
+test_l1_only_date_is_not_reported_abandoned
+test_l1_only_then_assemble
 test_no_sessions_stub_carries_marker
 test_old_date_reprocess_does_not_consume
 test_config_unbound_var_does_not_kill_run


### PR DESCRIPTION
Adds `AUTODREAM_L1_ONLY=1`: run enumeration and L1, write findings + `run-stats.txt`, skip L2, consume nothing, exit 0.

## Why

On a host running one install per harness, the useful division is *each install triages its own sessions, one aggregation runs over the union*. Without a seam for that, every install pays for an L2 whose report nobody reads, and a pattern with evidence in both harnesses lands split across two reports where neither can rank it. From a merged run over one real day (21 claude + 33 omp sessions):

> `### missed_skill (cross-source: skill invoked once, then agent went manual)`
> **Count**: 2 findings, 2 sessions — **1 claude + 1 omp** (this is the merged-only signal)

## Where the stop sits, and why exactly there

**After** the L2 *inputs* are assembled — findings JSONs, `run-stats.txt`, changelog window, operator notes, bookmarks — so the findings dir is left as a complete aggregation package for whoever assembles it.

**Before** anything that acts on a report. Notably before the stale-report move: that block exists to stop a previous report from being mistaken for this run's output, and running it here would rename a perfectly good report aside for a replacement this run is never going to write.

Everything that consumes input — the vault-notes archive, x-bookmark mark-read, project-memory GC, the open-questions inbox — is already gated on a complete report, so it is skipped by construction rather than by a second check I could get wrong. That is asserted, not assumed: a test drops a note in a vault inbox and a pin in a project `MEMORY.md`, runs L1-only, and requires both to be untouched.

## The marker

L1-only writes a `l1-only` file into the findings dir, and `unassembled_dates()` skips dirs that have it. Without this, the "findings but no complete report" warning fires **every night** on precisely the host this feature is for — which is how a real warning gets trained into background noise. The test includes the control: same findings dir with the marker removed is still reported, so the marker is doing the work rather than the scan having been broken.

## Why not `AUTODREAM_L2_ATTEMPTS=0`

It nearly works — `seq 1 0` is empty, so L2 never runs — but the run then takes the no-report path: a WARNING, a non-zero exit, and a date that looks abandoned in the self-audit. Fine for a one-off experiment, wrong for a nightly under launchd.

## Verification

- Suite **297 assertions, 0 failures** (283 baseline + 14 new; each watched failing first).
- `shellcheck --severity=warning bin/*.sh install.sh` and `--severity=error tests/*.sh` clean.
- Tests cover: findings land / no report / exit 0; nothing consumed (vault note + `MEMORY.md` + no `touched-projects.txt` + no inbox file); the date is not flagged abandoned, with the negative control; and a later normal run assembles the same date **without re-invoking L1** — asserted via `MOCK_CALL_LOG` on the session hash, which is the economic point of splitting the phases.

Default is off, so single-install behaviour is byte-identical.

The companion change is `STRML/omp-autodream#15`, so both halves of a two-install host can stop after L1. The merge tool that consumes the two findings dirs lives outside both repos and needs nothing further from either.
