### PR TITLE
fix: an unmarked report predating the marker contract is legacy, not abandoned

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -34,6 +34,10 @@
 #   AUTODREAM_FORCE      set 1 to rebuild even if a report exists    default: 0
 #   AUTODREAM_SLIM_BYTES sessions larger than this are slimmed for L1  default: 262144
 #   AUTODREAM_L2_MODEL   override the L2 aggregator model            default: fable-5 until 2026-06-20, claude-opus-4-7 from 2026-06-21
+#   AUTODREAM_MARKER_EPOCH    first date whose report is REQUIRED to carry the
+#                             open-questions marker; earlier unmarked reports are treated
+#                             as complete (legacy) rather than abandoned
+#                                                                     default: 2026-08-19
 #   AUTODREAM_MIN_USER_TURNS  noise-gate floor on user_message_count  default: 2
 #   AUTODREAM_MIN_MINUTES     noise-gate floor on duration_minutes    default: 1
 #   AUTODREAM_STATS_BIN       override the resolved session-stats.sh path, authoritative
@@ -662,16 +666,30 @@ dispatch_l1() { # one parallel pass; idempotent worker → only the still-missin
 }
 
 # Dates in the trailing window whose findings were produced but never assembled into a
-# complete report (#36). Echoes a comma-separated list, empty when there are none.
+# complete report (#36). Echoes "unassembled|legacy", both comma-separated, either empty.
 #
 # The completeness test is the open-questions marker, not `-s`, for the same reason every
 # other consumer uses it: a report killed mid-write is not a report. TARGET_DATE is skipped
 # because this run is about to assemble it, and a stub findings dir left by an earlier
 # attempt at the same date would otherwise report itself as a failure.
+#
+# The marker became mandatory partway through this tool's life, so every report written
+# before that is non-empty, complete, and unmarked. Judged by the marker alone they all
+# look abandoned: on this host the check named six consecutive good reports every single
+# night, which is exactly how a real warning gets trained into background noise. Dates
+# before AUTODREAM_MARKER_EPOCH therefore accept a non-empty report, and are reported
+# under their own key so the exemption is visible rather than silent.
+#
+# Why a date and not a heuristic: "non-empty but unmarked" is genuinely ambiguous - it is
+# either a legacy report or a truncated capture - and the only fact that separates them is
+# when the contract began. The exposure is bounded by design: the scan looks back
+# AUTODREAM_UNASSEMBLED_WINDOW days, so an epoch that is wrong for a given install
+# self-corrects within a week of upgrading. Set it when backfilling older dates.
 unassembled_dates() {
   local window="${AUTODREAM_UNASSEMBLED_WINDOW:-7}" root="$AUTODREAM_DIR/findings"
-  local d date_label report found out=""
-  [ -d "$root" ] || return 0
+  local epoch="${AUTODREAM_MARKER_EPOCH:-2026-08-19}"
+  local d date_label report found out="" legacy=""
+  [ -d "$root" ] || { printf '|'; return 0; }
   while IFS= read -r d; do
     [ -n "$d" ] || continue
     date_label=$(basename "$d")
@@ -681,13 +699,20 @@ unassembled_dates() {
     found=$(find "$d" -maxdepth 1 -type f -name '*.json' ! -name '*.stats.json' 2>/dev/null | head -1)
     [ -n "$found" ] || continue
     report="$DREAMS_DIR/$date_label.md"
-    if [ -s "$report" ] && grep -q 'autodream:open-questions=' "$report" 2>/dev/null; then
-      continue
+    if [ -s "$report" ]; then
+      grep -q 'autodream:open-questions=' "$report" 2>/dev/null && continue
+      # Non-empty and unmarked. Before the epoch that is a legacy report; on or after it,
+      # it is a truncated capture and stays on the abandoned list. ISO dates compare
+      # lexicographically, so this is chronological.
+      if [[ "$date_label" < "$epoch" ]]; then
+        legacy="${legacy:+$legacy, }$date_label"
+        continue
+      fi
     fi
     out="${out:+$out, }$date_label"
   done < <(find "$root" -maxdepth 1 -type d -name '2[0-9][0-9][0-9]-[0-1][0-9]-[0-3][0-9]' 2>/dev/null \
     | sort | tail -n "$window")
-  printf '%s' "$out"
+  printf '%s|%s' "$out" "$legacy"
 }
 
 run() {
@@ -720,10 +745,18 @@ run() {
   # Recovery is cheap whenever the findings survive (`autodream-now.sh <date>` skips
   # straight to L2), so the gap was never the data. It was that nobody was told. This says
   # so in the log and in run-stats.txt, which puts it in the next morning's report.
-  UNASSEMBLED=$(unassembled_dates)
+  _UNASSEMBLED_RAW=$(unassembled_dates)
+  UNASSEMBLED="${_UNASSEMBLED_RAW%%|*}"
+  LEGACY_MARKER="${_UNASSEMBLED_RAW##*|}"
   if [ -n "$UNASSEMBLED" ]; then
     log "WARNING: these dates have findings but no complete report: $UNASSEMBLED"
     log "         rebuild one cheaply with: $AUTODREAM_DIR/autodream-now.sh <date>"
+  fi
+  # Not a warning: these reports are fine, they just predate the marker. Logged so the
+  # exemption is auditable - if a date shows up here that should NOT be legacy, the epoch
+  # is wrong and that is worth seeing rather than inferring from a missing warning.
+  if [ -n "$LEGACY_MARKER" ]; then
+    log "note: unmarked reports predating AUTODREAM_MARKER_EPOCH (treated as complete): $LEGACY_MARKER"
   fi
 
   # ---- Idempotency guard: a finished report means we're done ----
@@ -1030,6 +1063,10 @@ PY
     # window, which is the reading that matters — this is the key that gets a killed run
     # noticed the next morning instead of during an unrelated investigation two days on.
     printf 'unassembled_dates: %s\n' "${UNASSEMBLED:-}"
+    # Always emitted, even empty: a reader should never have to tell "no legacy reports"
+    # apart from "this runner predates the key", which is the same ambiguity the epoch
+    # exists to resolve.
+    printf 'legacy_marker_reports: %s\n' "${LEGACY_MARKER:-}"
   } > "$FINDINGS_DIR/run-stats.txt"
 
   # ---- Upstream changelog window (writes changelog-window.md for L2 to read) ----

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -413,11 +413,44 @@ test_unassembled_ignores_a_finished_date(){
   printf '# report\n\nautodream:open-questions=0\n' > "$root/dreams/2020-01-01.md"
   run_dream "$root"
   assert_grep "$(fdir "$root")/run-stats.txt" "unassembled_dates: *$" "the finished date is not listed"
-  # A truncated report is not a finished one, and must come back onto the list.
+  # A truncated report is not a finished one, and must come back onto the list. The epoch
+  # is pinned to this fixture's date so the marker is REQUIRED here: that is the contract
+  # under test, and leaving it at the default would exempt every 2020 fixture date.
   printf '# report with no marker\n' > "$root/dreams/2020-01-01.md"
   rm -f "$root/dreams/$DATE.md"
-  run_dream "$root"
+  AUTODREAM_MARKER_EPOCH=2020-01-01 run_dream "$root"
   assert_grep "$(fdir "$root")/run-stats.txt" "unassembled_dates: 2020-01-01" "but a marker-less one is"
+  rm -rf "$root"
+}
+
+test_pre_marker_report_is_not_abandoned(){
+  echo "# a report written before the marker contract is complete, not abandoned"
+  local root; root=$(setup_env); mk_session "$root" s1
+  local prior="$root/autodream/findings/2020-01-01"
+  mkdir -p "$prior" "$root/dreams"
+  printf '{"findings":[]}\n' > "$prior/abc123def456.json"
+  # Real report, real content, no marker - exactly the six reports sitting in
+  # ~/.claude/dreams on this host, which the check called abandoned every single night.
+  printf '# Autodream - 2020-01-01\n\nreal content\n\n## Open questions\nNone.\n' > "$root/dreams/2020-01-01.md"
+  AUTODREAM_MARKER_EPOCH=2020-06-01 run_dream "$root"
+  assert_grep "$(fdir "$root")/run-stats.txt" "unassembled_dates: *$" "a pre-epoch report is not called abandoned"
+  assert_nogrep "$root/run.out" "findings but no complete report" "and no warning is logged for it"
+  assert_grep "$(fdir "$root")/run-stats.txt" "legacy_marker_reports: 2020-01-01" \
+    "it is counted separately, so the exemption is visible rather than silent"
+  rm -rf "$root"
+}
+
+test_missing_report_still_abandoned_before_epoch(){
+  echo "# the exemption is for unmarked reports only, never for a missing one"
+  local root; root=$(setup_env); mk_session "$root" s1
+  local prior="$root/autodream/findings/2020-01-01"
+  mkdir -p "$prior" "$root/dreams"
+  printf '{"findings":[]}\n' > "$prior/abc123def456.json"
+  # No report at all, and an epoch that would exempt an unmarked one. Findings with no
+  # report is the real failure the scan exists to catch; the epoch must not swallow it.
+  AUTODREAM_MARKER_EPOCH=2020-06-01 run_dream "$root"
+  assert_grep "$(fdir "$root")/run-stats.txt" "unassembled_dates: 2020-01-01" \
+    "a date with findings and no report is still abandoned"
   rm -rf "$root"
 }
 
@@ -1689,6 +1722,8 @@ test_complete_report_retires_partials
 test_dead_stdout_does_not_kill_the_run
 test_unassembled_dates_are_surfaced
 test_unassembled_ignores_a_finished_date
+test_pre_marker_report_is_not_abandoned
+test_missing_report_still_abandoned_before_epoch
 test_no_sessions_stub_carries_marker
 test_old_date_reprocess_does_not_consume
 test_config_unbound_var_does_not_kill_run


### PR DESCRIPTION
fix: an unmarked report predating the marker contract is legacy, not abandoned

The completeness scan judges a report by the open-questions marker, which is right for
catching a capture killed mid-write. But the marker became mandatory partway through this
tool's life, so every report written before that is non-empty, complete, and unmarked —
and indistinguishable, by that test, from a truncation.

Measured on a real install: nine consecutive good reports (2026-08-10 → 2026-08-18, all
4–12 KB, all sitting in ~/.claude/dreams) were named as abandoned, every night, in the log
and in run-stats.txt. Last night's report duly asked whether to spend six opus passes
rebuilding reports that already exist. That is how a real warning gets trained into
background noise.

Dates before AUTODREAM_MARKER_EPOCH (default 2026-08-19) now accept a non-empty report and
are reported under legacy_marker_reports instead. The two cases the scan exists to catch
are untouched: findings with NO report is still abandoned regardless of epoch, and an
unmarked report on or after the epoch is still a truncation.

Why a date rather than a heuristic: "non-empty but unmarked" is genuinely ambiguous, and
the only fact separating legacy from truncated is when the contract began. Exposure is
bounded by design — the scan looks back AUTODREAM_UNASSEMBLED_WINDOW days, so an epoch
that is wrong for a given install self-corrects within a week of upgrading.

The exemption is logged and counted rather than silent: a date appearing under
legacy_marker_reports that should not be legacy means the epoch is wrong, which is worth
seeing rather than inferring from an absent warning. The key is emitted even when empty, so
a reader never has to tell "none" from "this runner predates the key".

Suite 287, 0 failures (283 + 4 new, each watched failing first). One existing assertion
gained an explicit AUTODREAM_MARKER_EPOCH pin: it covers the truncation guard, every
fixture date is in 2020, and the default epoch would otherwise exempt it — the pin keeps
the case it was written for. Verified against the real install by extracting the shipped
function: default epoch yields unassembled [], legacy [nine dates]; epoch=2026-01-01 puts
all nine back on the abandoned list.
