### PR TITLE
fix: the OMP strip invented content that was never in the transcript

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,8 @@ jobs:
         run: |
           rc=0
           for t in tests/lib-project.sh tests/preflight.sh tests/adapters.sh \
-                   tests/adapter-claude.sh tests/adapter-contract.sh; do
+                   tests/adapter-claude.sh tests/adapter-contract.sh \
+                   tests/slim-transcript.sh; do
             echo "== $t"
             bash "$t" || rc=1
           done

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,8 @@ findings/
 logs/
 inbox/
 .serena/
+# Scratch dirs for the multi-model review panels (/debate:run, /code-review).
+# 6.7MB of them accumulated untracked, and because they hold full file dumps
+# every repo-wide grep matched them dozens of times over.
+.tmp/
 .claude/settings.local.json

--- a/bin/slim-transcript.sh
+++ b/bin/slim-transcript.sh
@@ -122,6 +122,20 @@ if command -v jq >/dev/null 2>&1; then
                # where its data actually lives, and only if it is there.
                elif .type == "image" then
                  (if (.source | payload) then .source = "[autodream: image stripped]" else . end)
+                 # OMP keeps its image payload in .data, which this branch did not
+                 # touch at all. But .data is NOT always a payload: measured across
+                 # 400 real OMP transcripts on this host, all 289 image blocks carry
+                 # `blob:sha256:<hash>`, a 76-char content-addressed reference
+                 # totalling 22KB against a 262144-byte cap. Replacing those with a
+                 # marker would delete an identifier triage can use and save
+                 # nothing. Only an inline data: URI is a payload, so only that is
+                 # stripped; anything else goes through trunc as a backstop for a
+                 # shape neither of us has seen.
+                 | (if (.data | payload) then
+                      .data = (if (.data | type) == "string" and (.data | startswith("data:"))
+                                 then "[autodream: image stripped]"
+                                 else (.data | trunc($tr)) end)
+                    else . end)
                elif .type == "image_url" then
                  (if (.image_url | payload) then .image_url = "[autodream: image stripped]" else . end)
                else . end)

--- a/bin/slim-transcript.sh
+++ b/bin/slim-transcript.sh
@@ -85,8 +85,13 @@ if command -v jq >/dev/null 2>&1; then
              .content |= map(
                if .type == "tool_result" then
                  # Preserve tool_use_id + is_error so triage can still tell which
-                 # call failed; only the heavy content array goes.
-                 .content = "[autodream: tool_result payload stripped]"
+                 # call failed; only the heavy content array goes. has() guard for
+                 # the same reason as everywhere else in this program: without it a
+                 # block carrying no content came out ASSERTING that content was
+                 # stripped, which is a claim about a payload that never existed.
+                 (if has("content")
+                    then .content = "[autodream: tool_result payload stripped]"
+                    else . end)
                elif .type == "thinking" then
                  # has() guard and NO `// ""`. The first version wrote
                  # `.thinking = ((.thinking // "") | trunc($tk))`, which invented
@@ -99,8 +104,18 @@ if command -v jq >/dev/null 2>&1; then
                elif .type == "toolCall" then
                  del(.partialArgs)
                  | (if has("arguments") then .arguments = (.arguments | trunc($tr)) else . end)
-               elif .type == "image" or .type == "image_url" then
-                 .source = "[autodream: image stripped]"
+               # The two image shapes keep their payload in DIFFERENT places, and
+               # collapsing them cost this branch its entire purpose. Claude puts
+               # the base64 in .source; an OpenAI-style image_url block puts it in
+               # .image_url.url. Setting .source on BOTH left the image_url payload
+               # completely intact and added a marker claiming it had been removed
+               # — a file whose header promises to strip base64 image data, shipping
+               # the base64 and a receipt for its deletion. Each shape is stripped
+               # where its data actually lives, and only if it is there.
+               elif .type == "image" then
+                 (if has("source") then .source = "[autodream: image stripped]" else . end)
+               elif .type == "image_url" then
+                 (if has("image_url") then .image_url = "[autodream: image stripped]" else . end)
                else . end)
            else . end)
       )

--- a/bin/slim-transcript.sh
+++ b/bin/slim-transcript.sh
@@ -60,6 +60,14 @@ if command -v jq >/dev/null 2>&1; then
     # structured .arguments object was flattened to an escaped JSON string even
     # when it was 40x under the cap — destroying the very structure triage reads.
     # Verified against this exact program with jq before and after.
+    # PRESENCE IS NOT A PAYLOAD. A presence check is true when the field is
+    # null, so every guard below turned a null into a marker announcing that a
+    # payload had been stripped -- the same false claim these guards exist to
+    # stop, one level in. An absent key reads as null in jq, so this subsumes
+    # the presence check. An empty object counts as no payload, since an
+    # image_url of {} carries no url.
+    def payload: . != null and (type != "object" or length > 0);
+
     def trunc($n):
       if . == null then null
       elif type == "string" then
@@ -74,7 +82,7 @@ if command -v jq >/dev/null 2>&1; then
         del(.providerPayload)
         # OMP: a whole record is one tool result.
         | (if .role == "toolResult" then
-             (if has("details") then .details = "[autodream: details stripped]" else . end)
+             (if (.details | payload) then .details = "[autodream: details stripped]" else . end)
              # has() guard, not a bare assignment: `.content = (...)` CREATES the
              # key on a record that never had one.
              | (if has("content") then .content = (.content | trunc($tr)) else . end)
@@ -89,7 +97,7 @@ if command -v jq >/dev/null 2>&1; then
                  # the same reason as everywhere else in this program: without it a
                  # block carrying no content came out ASSERTING that content was
                  # stripped, which is a claim about a payload that never existed.
-                 (if has("content")
+                 (if (.content | payload)
                     then .content = "[autodream: tool_result payload stripped]"
                     else . end)
                elif .type == "thinking" then
@@ -113,9 +121,9 @@ if command -v jq >/dev/null 2>&1; then
                # the base64 and a receipt for its deletion. Each shape is stripped
                # where its data actually lives, and only if it is there.
                elif .type == "image" then
-                 (if has("source") then .source = "[autodream: image stripped]" else . end)
+                 (if (.source | payload) then .source = "[autodream: image stripped]" else . end)
                elif .type == "image_url" then
-                 (if has("image_url") then .image_url = "[autodream: image stripped]" else . end)
+                 (if (.image_url | payload) then .image_url = "[autodream: image stripped]" else . end)
                else . end)
            else . end)
       )

--- a/bin/slim-transcript.sh
+++ b/bin/slim-transcript.sh
@@ -88,7 +88,14 @@ if command -v jq >/dev/null 2>&1; then
                  # call failed; only the heavy content array goes.
                  .content = "[autodream: tool_result payload stripped]"
                elif .type == "thinking" then
-                 .thinking = ((.thinking // "") | trunc($tk))
+                 # has() guard and NO `// ""`. The first version wrote
+                 # `.thinking = ((.thinking // "") | trunc($tk))`, which invented
+                 # `thinking: ""` on a block that never carried the key and turned
+                 # an explicit null into an empty string — the same fabrication
+                 # the parent commit fixed for .content and .arguments, at the
+                 # third site of the same class three lines away. trunc handles
+                 # null on its own now, so the `//` was doing nothing but harm.
+                 (if has("thinking") then .thinking = (.thinking | trunc($tk)) else . end)
                elif .type == "toolCall" then
                  del(.partialArgs)
                  | (if has("arguments") then .arguments = (.arguments | trunc($tr)) else . end)

--- a/bin/slim-transcript.sh
+++ b/bin/slim-transcript.sh
@@ -14,7 +14,8 @@
 #
 # Usage: slim-transcript.sh <src.jsonl> <dst>
 # Tunables (env): AUTODREAM_SLIM_MAXLINE (400 chars), _HEAD (400 lines),
-#                 _TAIL (200 lines), _CAP (262144 bytes).
+#                 _TAIL (200 lines), _CAP (262144 bytes),
+#                 _TOOLRESULT (600 chars), _THINKING (800 chars).
 set -u
 
 src="${1:?usage: slim-transcript.sh <src> <dst>}"
@@ -23,35 +24,78 @@ maxline="${AUTODREAM_SLIM_MAXLINE:-400}"
 headn="${AUTODREAM_SLIM_HEAD:-400}"
 tailn="${AUTODREAM_SLIM_TAIL:-200}"
 cap="${AUTODREAM_SLIM_CAP:-262144}"
+trmax="${AUTODREAM_SLIM_TOOLRESULT:-600}"
+tkmax="${AUTODREAM_SLIM_THINKING:-800}"
 
 [ -r "$src" ] || { echo "slim-transcript: cannot read $src" >&2; exit 1; }
 
 lines=$(wc -l < "$src" | tr -d ' ')
 bytes=$(wc -c < "$src" | tr -d ' ')
 
-# Pre-pass: when jq is available, strip the bulky payloads inside tool_result
-# entries (and base64 image_url data) before the line-based head/tail/truncate
-# pass. Orchestrator/review-fan-out transcripts spend most of their bytes on
-# tool_result blocks (entire diffs, file dumps, gh JSON), so cutting just the
-# *.message.content tool_result fields shrinks the file 5-20x while leaving the
-# turn structure intact for fuzzy pattern-spotting. The line-based pass below
-# still runs as a safety net (caps stragglers like assistant turns that paste
-# huge code blocks). Falls back transparently if jq isn't installed or the
-# stream isn't pure JSONL (e.g. a non-Claude session schema we don't know).
+# Pre-pass: when jq is available, strip the bulky payloads that tool calls leave
+# behind, before the line-based head/tail/truncate pass. Two transcript schemas
+# show up here and they store tool output in completely different places:
+#
+#   Claude Code  content blocks of .type == "tool_result" inside .message.content
+#   OMP          whole records with .message.role == "toolResult", carrying the
+#                payload in .message.details + .message.content, plus a
+#                .message.providerPayload blob on assistant turns
+#
+# Handling only the first schema is worse than doing nothing: jq still exits 0 and
+# writes a valid file, so the fallback never fires, and the line pass below then
+# spends its 400-char budget on ~190 chars of OMP envelope (id/parentId/timestamp/
+# toolCallId/toolName) and cuts off at '"content":[' — the worker gets ID soup with
+# no payload and no goal, and returns no findings. Both schemas are stripped here.
+# The line-based pass still runs as a safety net for stragglers. Falls back
+# transparently if jq isn't installed or the stream isn't parseable JSONL.
 pre_src="$src"
 pre_tmp=""
 if command -v jq >/dev/null 2>&1; then
   pre_tmp="$dst.pre.jsonl"
-  if jq -c '
-    if (.message.content | type) == "array" then
-      .message.content |= map(
-        if .type == "tool_result" then
-          # Replace the heavy content array with a one-line marker, preserve
-          # tool_use_id + is_error so triage can still tell which call failed.
-          .content = "[autodream: tool_result payload stripped]"
-        elif .type == "image" or .type == "image_url" then
-          .source = "[autodream: image stripped]"
-        else . end
+  if jq -c --argjson tr "$trmax" --argjson tk "$tkmax" '
+    # tostring is applied ONLY when the value is over the cap, and never to null.
+    # The first version ran it unconditionally, which did three wrong things: a
+    # toolResult with .content null came out carrying the literal string "null",
+    # a record with NO .content had the key invented and set to "null", and a
+    # structured .arguments object was flattened to an escaped JSON string even
+    # when it was 40x under the cap — destroying the very structure triage reads.
+    # Verified against this exact program with jq before and after.
+    def trunc($n):
+      if . == null then null
+      elif type == "string" then
+        (if length > $n then .[0:$n] + "…[autodream: truncated]" else . end)
+      else
+        (tostring as $s
+         | if ($s | length) > $n then $s[0:$n] + "…[autodream: truncated]" else . end)
+      end;
+    if (.message | type) == "object" then
+      .message |= (
+        # Raw provider round-trip, never useful for triage.
+        del(.providerPayload)
+        # OMP: a whole record is one tool result.
+        | (if .role == "toolResult" then
+             (if has("details") then .details = "[autodream: details stripped]" else . end)
+             # has() guard, not a bare assignment: `.content = (...)` CREATES the
+             # key on a record that never had one.
+             | (if has("content") then .content = (.content | trunc($tr)) else . end)
+           else . end)
+        # Claude Code: tool results are blocks. Also caps oversized thinking and
+        # tool-call arguments in either schema.
+        | (if (.content | type) == "array" then
+             .content |= map(
+               if .type == "tool_result" then
+                 # Preserve tool_use_id + is_error so triage can still tell which
+                 # call failed; only the heavy content array goes.
+                 .content = "[autodream: tool_result payload stripped]"
+               elif .type == "thinking" then
+                 .thinking = ((.thinking // "") | trunc($tk))
+               elif .type == "toolCall" then
+                 del(.partialArgs)
+                 | (if has("arguments") then .arguments = (.arguments | trunc($tr)) else . end)
+               elif .type == "image" or .type == "image_url" then
+                 .source = "[autodream: image stripped]"
+               else . end)
+           else . end)
       )
     else . end
   ' "$src" > "$pre_tmp" 2>/dev/null && [ -s "$pre_tmp" ]; then

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -2635,7 +2635,7 @@ test_all_excluded_corpus_says_so
 # Their counts fold into the totals below, so a red unit suite fails this script.
 echo
 echo "===== unit suites ====="
-for _suite in lib-project preflight adapters adapter-claude adapter-contract; do
+for _suite in lib-project preflight adapters adapter-claude adapter-contract slim-transcript; do
   _out=$(bash "$HERE/$_suite.sh" 2>&1)
   _rc=$?
   _p=$(printf '%s\n' "$_out" | sed -n 's/^passed: *\([0-9][0-9]*\).*/\1/p' | tail -1)

--- a/tests/slim-transcript.sh
+++ b/tests/slim-transcript.sh
@@ -21,7 +21,15 @@ ok(){ printf '  ok   - %s\n' "$1"; pass=$((pass + 1)); }
 no(){ printf '  FAIL - %s\n' "$1"; fail=$((fail + 1)); }
 assert_eq(){ [ "$1" = "$2" ] && ok "$3" || no "$3 (got [$1] want [$2])"; }
 has(){ case "$2" in *"$1"*) ok "$3" ;; *) no "$3 (got: [$2])" ;; esac; }
-hasnt(){ case "$2" in *"$1"*) no "$3 (found [$1] in: [$2])" ;; *) ok "$3" ;; esac; }
+# An EMPTY haystack is a failure, not a pass. Every `hasnt` in this file was
+# vacuous whenever the slimmer produced no output at all — the strongest possible
+# regression, a slimmer that emits nothing, satisfied all of them. The guard lives
+# in the helper because the defect is the helper's, not any one call site's.
+# `has` and `jq_is` already fail on empty input by construction.
+hasnt(){
+  [ -n "$2" ] || { no "$3 (nothing to check: the slimmer produced no output)"; return; }
+  case "$2" in *"$1"*) no "$3 (found [$1] in: [$2])" ;; *) ok "$3" ;; esac
+}
 # Type and presence claims go through jq, never through a substring match.
 # The first version asserted `hasnt '\\"file\\"'` to mean "not stringified" —
 # jq emits ONE backslash there, so the pattern could never match and the
@@ -63,7 +71,10 @@ echo "# slim: a null or absent value is not turned into the string \"null\""
 # a toolResult carrying no content came out asserting the literal text "null" —
 # a value the worker reads as real tool output.
 got=$(slim_one '{"message":{"role":"toolResult","content":null,"toolName":"Read"}}')
-jq_is "$got" '.message.content | type' 'null' "a null .content stays JSON null, not the string \"null\""
+# BOTH assertions, because `type` alone reports "null" for an absent key too, so
+# a regression that simply deleted .content would satisfy the type check.
+jq_is "$got" '.message | has("content")' 'true' "an explicit null .content is KEPT, not deleted"
+jq_is "$got" '.message.content | type' 'null' "and stays JSON null, not the string \"null\""
 has '"toolName":"Read"' "$got" "and the rest of the record survives"
 
 got=$(slim_one '{"message":{"role":"toolResult","toolName":"Read"}}')
@@ -94,17 +105,20 @@ has 'autodream: truncated' "$got" "a 700-char content is truncated at the 600 ca
 
 echo "# slim: Claude Code tool_result blocks are stripped, provenance kept"
 got=$(slim_one '{"message":{"content":[{"type":"tool_result","tool_use_id":"tu_1","is_error":true,"content":[{"type":"text","text":"HUGE"}]}]}}')
-has 'payload stripped' "$got" "the payload goes"
+has 'payload stripped' "$got" "the marker is inserted"
+hasnt 'HUGE' "$got" "and the original payload is actually GONE, not just annotated"
 has '"tool_use_id":"tu_1"' "$got" "tool_use_id is kept so triage can name the call"
 has '"is_error":true' "$got" "is_error is kept so triage can tell a failure"
 
 echo "# slim: OMP toolResult details are stripped"
 got=$(slim_one '{"message":{"role":"toolResult","details":{"big":"payload"},"content":"short"}}')
-has 'details stripped' "$got" "OMP .details is stripped"
+has 'details stripped' "$got" "OMP .details gets the marker"
+hasnt '"big":"payload"' "$got" "and the original details payload is actually gone"
 has '"content":"short"' "$got" "a short OMP content survives intact"
 
 echo "# slim: providerPayload never survives"
 got=$(slim_one '{"message":{"role":"assistant","providerPayload":{"raw":"secretish"},"content":"hi"}}')
+jq_is "$got" '.message.content' 'hi' "the assistant record itself survives"
 hasnt 'providerPayload' "$got" "the raw provider round-trip is dropped"
 hasnt 'secretish' "$got" "and its contents go with it"
 

--- a/tests/slim-transcript.sh
+++ b/tests/slim-transcript.sh
@@ -162,6 +162,19 @@ jq_is "$got" '.message.content[0] | has("content")' 'false' \
   "no content key is invented on a payload-free tool_result"
 jq_is "$got" '.message.content[0].tool_use_id' 'u1' "and the block survives"
 
+echo "# slim: a null or empty field is not marked as a stripped payload"
+# Presence is not a payload. `has("details")` is true when details is null, so
+# every marker site announced a removal that never happened when the field was
+# there but empty. One level in from the bug the markers exist to prevent.
+jq_is "$(slim_one '{"message":{"role":"toolResult","details":null,"content":"x"}}')" \
+  '.message.details | type' 'null' "a null .details is left alone, not marked stripped"
+jq_is "$(slim_one '{"message":{"content":[{"type":"image","source":null}]}}')" \
+  '.message.content[0].source | type' 'null' "a null image .source is left alone"
+jq_is "$(slim_one '{"message":{"content":[{"type":"image_url","image_url":{}}]}}')" \
+  '.message.content[0].image_url | length' '0' "an EMPTY image_url carries no url, so nothing is claimed"
+jq_is "$(slim_one '{"message":{"content":[{"type":"tool_result","tool_use_id":"u1","content":null}]}}')" \
+  '.message.content[0].content | type' 'null' "a null tool_result .content is left alone"
+
 echo "# slim: OMP toolResult details are stripped"
 got=$(slim_one '{"message":{"role":"toolResult","details":{"big":"payload"},"content":"short"}}')
 has 'details stripped' "$got" "OMP .details gets the marker"

--- a/tests/slim-transcript.sh
+++ b/tests/slim-transcript.sh
@@ -142,6 +142,26 @@ hasnt 'HUGE' "$got" "and the original payload is actually GONE, not just annotat
 has '"tool_use_id":"tu_1"' "$got" "tool_use_id is kept so triage can name the call"
 has '"is_error":true' "$got" "is_error is kept so triage can tell a failure"
 
+echo "# slim: image payloads leave, in BOTH shapes"
+# This branch claimed to strip base64 image data from the day it was written and
+# did not, for image_url. It set .source (Claude's field) on a block whose payload
+# lives at .image_url.url, so the base64 stayed and the record gained a marker
+# saying it had gone. A receipt for a deletion that never happened.
+got=$(slim_one '{"message":{"content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,SECRETPAYLOAD"}}]}}')
+hasnt 'SECRETPAYLOAD' "$got" "an image_url base64 payload is actually removed"
+has 'image stripped' "$got" "and the block says so"
+got=$(slim_one '{"message":{"content":[{"type":"image","source":{"data":"BASE64HERE"}}]}}')
+hasnt 'BASE64HERE' "$got" "a Claude image .source payload is actually removed"
+got=$(slim_one '{"message":{"content":[{"type":"image_url","alt":"a chart"}]}}')
+jq_is "$got" '.message.content[0] | has("image_url")' 'false' \
+  "an image_url block with no payload does not have one invented"
+
+echo "# slim: a tool_result with no content does not claim one was stripped"
+got=$(slim_one '{"message":{"content":[{"type":"tool_result","tool_use_id":"u1"}]}}')
+jq_is "$got" '.message.content[0] | has("content")' 'false' \
+  "no content key is invented on a payload-free tool_result"
+jq_is "$got" '.message.content[0].tool_use_id' 'u1' "and the block survives"
+
 echo "# slim: OMP toolResult details are stripped"
 got=$(slim_one '{"message":{"role":"toolResult","details":{"big":"payload"},"content":"short"}}')
 has 'details stripped' "$got" "OMP .details gets the marker"

--- a/tests/slim-transcript.sh
+++ b/tests/slim-transcript.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Unit tests for bin/slim-transcript.sh's jq pre-pass.
+#
+# The pre-pass handles two transcript schemas that store tool output in
+# completely different places, and it fails SILENTLY when it gets one wrong: jq
+# exits 0 and writes a valid file, so the shell fallback never fires and the
+# line-based pass downstream happily truncates an OMP envelope at '"content":['.
+# The worker then receives ID soup and returns no findings, which looks exactly
+# like a quiet day.
+#
+# So these assertions are about what SURVIVES the strip, not about whether the
+# script exits 0. Every one of them passed a smoke test before it was written.
+set -u
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+REPO=$(cd "$HERE/.." && pwd)
+SLIM="$REPO/bin/slim-transcript.sh"
+
+pass=0; fail=0
+ok(){ printf '  ok   - %s\n' "$1"; pass=$((pass + 1)); }
+no(){ printf '  FAIL - %s\n' "$1"; fail=$((fail + 1)); }
+assert_eq(){ [ "$1" = "$2" ] && ok "$3" || no "$3 (got [$1] want [$2])"; }
+has(){ case "$2" in *"$1"*) ok "$3" ;; *) no "$3 (got: [$2])" ;; esac; }
+hasnt(){ case "$2" in *"$1"*) no "$3 (found [$1] in: [$2])" ;; *) ok "$3" ;; esac; }
+
+[ -x "$SLIM" ] || {
+  printf '  FAIL - bin/slim-transcript.sh missing or not executable\n'
+  printf '\npassed: 0   failed: 1\n'; exit 1; }
+command -v jq >/dev/null 2>&1 || {
+  printf '  ok   - jq not installed; the pre-pass is skipped and so is this suite\n'
+  printf '\npassed: 1   failed: 0\n'; exit 0; }
+
+TMP=$(mktemp -d "${TMPDIR:-/tmp}/slimtest.XXXXXX")
+trap 'rm -rf "$TMP"' EXIT
+
+# Run the slimmer over one JSONL record and print the result. head/tail/cap are
+# raised well clear so ONLY the jq pre-pass is under test; the line-based pass is
+# a separate mechanism and would otherwise mask what the pre-pass did.
+slim_one() { # $1=json record -> slimmed record on stdout
+  printf '%s\n' "$1" > "$TMP/in.jsonl"
+  AUTODREAM_SLIM_MAXLINE=100000 AUTODREAM_SLIM_HEAD=9000 AUTODREAM_SLIM_TAIL=9000 \
+  AUTODREAM_SLIM_CAP=100000000 \
+    "$SLIM" "$TMP/in.jsonl" "$TMP/out.txt" >/dev/null 2>&1
+  grep -m1 '^{' "$TMP/out.txt" 2>/dev/null
+}
+
+echo "# slim: a null or absent value is not turned into the string \"null\""
+# The bug this suite was written for. `trunc` ran `tostring` unconditionally, so
+# a toolResult carrying no content came out asserting the literal text "null" —
+# a value the worker reads as real tool output.
+got=$(slim_one '{"message":{"role":"toolResult","content":null,"toolName":"Read"}}')
+hasnt '"null"' "$got" "a null .content does not become the string \"null\""
+has '"toolName":"Read"' "$got" "and the rest of the record survives"
+
+got=$(slim_one '{"message":{"role":"toolResult","toolName":"Read"}}')
+hasnt '"content"' "$got" "an ABSENT .content is not invented as a key"
+
+echo "# slim: a small structured value keeps its structure"
+# tostring flattened `arguments` to an escaped JSON string even 40x under the
+# cap, so triage lost the field names it reads. Structure is the payload here.
+got=$(slim_one '{"message":{"content":[{"type":"toolCall","arguments":{"file":"a.txt","n":3}}]}}')
+has '"file":"a.txt"' "$got" "short arguments stay an object, not an escaped string"
+hasnt '\\"file\\"' "$got" "and are not stringified"
+
+echo "# slim: an oversized value IS truncated"
+# The cap has to still work, or the fix above traded one silent failure for a
+# different one. 700 chars against a 600-char cap.
+big=$(printf 'x%.0s' $(seq 1 700))
+got=$(slim_one "{\"message\":{\"role\":\"toolResult\",\"content\":\"$big\"}}")
+has 'autodream: truncated' "$got" "a 700-char content is truncated at the 600 cap"
+[ "${#got}" -lt 900 ] && ok "and the record shrank" || no "and the record shrank (len ${#got})"
+
+echo "# slim: Claude Code tool_result blocks are stripped, provenance kept"
+got=$(slim_one '{"message":{"content":[{"type":"tool_result","tool_use_id":"tu_1","is_error":true,"content":[{"type":"text","text":"HUGE"}]}]}}')
+has 'payload stripped' "$got" "the payload goes"
+has '"tool_use_id":"tu_1"' "$got" "tool_use_id is kept so triage can name the call"
+has '"is_error":true' "$got" "is_error is kept so triage can tell a failure"
+
+echo "# slim: OMP toolResult details are stripped"
+got=$(slim_one '{"message":{"role":"toolResult","details":{"big":"payload"},"content":"short"}}')
+has 'details stripped' "$got" "OMP .details is stripped"
+has '"content":"short"' "$got" "a short OMP content survives intact"
+
+echo "# slim: providerPayload never survives"
+got=$(slim_one '{"message":{"role":"assistant","providerPayload":{"raw":"secretish"},"content":"hi"}}')
+hasnt 'providerPayload' "$got" "the raw provider round-trip is dropped"
+hasnt 'secretish' "$got" "and its contents go with it"
+
+echo "# slim: a record the pre-pass does not understand passes through"
+# The fallback is the whole reason this is safe to run on an unknown schema.
+got=$(slim_one '{"type":"queue-operation","payload":{"a":1}}')
+has 'queue-operation' "$got" "an unknown record shape is not dropped"
+
+echo "# slim: non-JSONL input falls back instead of producing nothing"
+printf 'this is not json\nnor is this\n' > "$TMP/plain.txt"
+AUTODREAM_SLIM_MAXLINE=100000 "$SLIM" "$TMP/plain.txt" "$TMP/plain.out" >/dev/null 2>&1
+rc=$?
+assert_eq "$rc" "0" "a non-JSONL transcript still exits 0"
+[ -s "$TMP/plain.out" ] && ok "and still writes output" || no "and still writes output"
+has 'this is not json' "$(cat "$TMP/plain.out" 2>/dev/null)" "the original text survives the fallback"
+
+echo "# slim: no .pre.jsonl temp is left behind"
+ls "$TMP"/*.pre.jsonl >/dev/null 2>&1 && no "the pre-pass temp is cleaned up" \
+  || ok "the pre-pass temp is cleaned up"
+
+printf '\npassed: %s   failed: %s\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/slim-transcript.sh
+++ b/tests/slim-transcript.sh
@@ -156,6 +156,19 @@ got=$(slim_one '{"message":{"content":[{"type":"image_url","alt":"a chart"}]}}')
 jq_is "$got" '.message.content[0] | has("image_url")' 'false' \
   "an image_url block with no payload does not have one invented"
 
+echo "# slim: OMP image .data is stripped only when it IS a payload"
+# Grounded in the corpus, not the schema. All 289 image blocks across 400 real OMP
+# transcripts on the author's host carry `blob:sha256:<hash>` — a 76-char
+# content-addressed reference, 22KB in total against a 262144-byte cap. Marking
+# those "stripped" would delete an identifier and reclaim nothing, so only an
+# inline data: URI counts as a payload here.
+got=$(slim_one '{"message":{"content":[{"type":"image","data":"blob:sha256:ea5b55c53f28e07af31be6686b1281d9e4cd7bab9fbf9c4f65dc432affd2a010","mimeType":"image/webp"}]}}')
+has 'blob:sha256:ea5b55c5' "$got" "a blob reference SURVIVES; it is an id, not a payload"
+jq_is "$got" '.message.content[0].mimeType' 'image/webp' "and the block keeps its metadata"
+got=$(slim_one '{"message":{"content":[{"type":"image","data":"data:image/png;base64,SECRETPAYLOAD","mimeType":"image/png"}]}}')
+hasnt 'SECRETPAYLOAD' "$got" "an inline data: URI payload is removed"
+jq_is "$got" '.message.content[0].mimeType' 'image/png' "while its metadata is kept"
+
 echo "# slim: a tool_result with no content does not claim one was stripped"
 got=$(slim_one '{"message":{"content":[{"type":"tool_result","tool_use_id":"u1"}]}}')
 jq_is "$got" '.message.content[0] | has("content")' 'false' \

--- a/tests/slim-transcript.sh
+++ b/tests/slim-transcript.sh
@@ -35,8 +35,13 @@ hasnt(){
 # jq emits ONE backslash there, so the pattern could never match and the
 # assertion passed whatever the code did. It survived the red-then-green check
 # for the same reason. An assertion that cannot fail is decoration.
-jq_is(){ # $1=record $2=jq expr $3=want $4=msg
-  local g; g=$(printf '%s' "$1" | jq -r "$2" 2>/dev/null)
+jq_is(){ # $1=slimmer output (may be several lines) $2=jq expr $3=want $4=msg
+  local rec g rc
+  rec=$(printf '%s\n' "$1" | grep -m1 '^{')
+  # jq's exit status is checked. Ignoring it meant a record that produced the
+  # expected value and THEN hit malformed bytes still passed.
+  g=$(printf '%s' "$rec" | jq -r "$2" 2>/dev/null); rc=$?
+  [ "$rc" -eq 0 ] || { no "$4 (jq exit $rc on: [$rec])"; return; }
   assert_eq "$g" "$3" "$4"
 }
 
@@ -63,8 +68,21 @@ slim_one() { # $1=json record -> slimmed record on stdout, or nothing on failure
   AUTODREAM_SLIM_MAXLINE=100000 AUTODREAM_SLIM_HEAD=9000 AUTODREAM_SLIM_TAIL=9000 \
   AUTODREAM_SLIM_CAP=100000000 \
     "$SLIM" "$TMP/in.jsonl" "$TMP/out.txt" >/dev/null 2>&1 || return 1
-  grep -m1 '^{' "$TMP/out.txt" 2>/dev/null
+  # The WHOLE output, not `grep -m1 '^{'`. Returning only the first record meant
+  # every negative assertion inspected one line, so a slimmer emitting a clean
+  # record followed by the original payload on line two passed them all. jq_is
+  # picks the first record out for itself.
+  cat "$TMP/out.txt" 2>/dev/null
 }
+
+echo "# slim: the script parses at all"
+# Cheap, and it would have caught the bug that produced this line. The jq program
+# is a single-quoted shell string, so ONE apostrophe anywhere inside it — in a
+# comment, in the word "commit's" — terminates the quote and the whole file stops
+# parsing. CLAUDE.md documents this trap for run.sh's L1 worker body; it applies
+# to every single-quoted program in this repo.
+if bash -n "$SLIM" 2>/dev/null; then ok "bin/slim-transcript.sh parses"
+else no "bin/slim-transcript.sh has a shell syntax error (stray apostrophe in the jq program?)"; fi
 
 echo "# slim: a null or absent value is not turned into the string \"null\""
 # The bug this suite was written for. `trunc` ran `tostring` unconditionally, so
@@ -79,6 +97,7 @@ has '"toolName":"Read"' "$got" "and the rest of the record survives"
 
 got=$(slim_one '{"message":{"role":"toolResult","toolName":"Read"}}')
 jq_is "$got" '.message | has("content")' 'false' "an ABSENT .content is not invented as a key"
+jq_is "$got" '.message.toolName' 'Read' "and the surrounding record is not simply dropped"
 
 echo "# slim: a small structured value keeps its structure"
 # tostring flattened `arguments` to an escaped JSON string even 40x under the
@@ -94,6 +113,19 @@ jq_is "$got" '.message.content[0].arguments.file' 'a.txt' "and the field names t
 got=$(slim_one '{"message":{"content":[{"type":"toolCall","toolName":"Read"}]}}')
 jq_is "$got" '.message.content[0] | has("arguments")' 'false' \
   "an ABSENT .arguments is not invented either"
+jq_is "$got" '.message.content[0].type' 'toolCall' "and that block is not simply dropped"
+
+echo "# slim: thinking blocks are capped without being fabricated"
+got=$(slim_one '{"message":{"content":[{"type":"thinking","signature":"sig1"}]}}')
+jq_is "$got" '.message.content[0] | has("thinking")' 'false' \
+  "an ABSENT .thinking is not invented as an empty string"
+jq_is "$got" '.message.content[0].signature' 'sig1' "and the block survives"
+got=$(slim_one '{"message":{"content":[{"type":"thinking","thinking":null}]}}')
+jq_is "$got" '.message.content[0].thinking | type' 'null' \
+  "an explicit null .thinking stays null, not \"\""
+bigt=$(printf 'y%.0s' $(seq 1 900))
+got=$(slim_one "{\"message\":{\"content\":[{\"type\":\"thinking\",\"thinking\":\"$bigt\"}]}}")
+has 'autodream: truncated' "$got" "a 900-char thinking block is capped at 800"
 
 echo "# slim: an oversized value IS truncated"
 # The cap has to still work, or the fix above traded one silent failure for a

--- a/tests/slim-transcript.sh
+++ b/tests/slim-transcript.sh
@@ -22,6 +22,15 @@ no(){ printf '  FAIL - %s\n' "$1"; fail=$((fail + 1)); }
 assert_eq(){ [ "$1" = "$2" ] && ok "$3" || no "$3 (got [$1] want [$2])"; }
 has(){ case "$2" in *"$1"*) ok "$3" ;; *) no "$3 (got: [$2])" ;; esac; }
 hasnt(){ case "$2" in *"$1"*) no "$3 (found [$1] in: [$2])" ;; *) ok "$3" ;; esac; }
+# Type and presence claims go through jq, never through a substring match.
+# The first version asserted `hasnt '\\"file\\"'` to mean "not stringified" —
+# jq emits ONE backslash there, so the pattern could never match and the
+# assertion passed whatever the code did. It survived the red-then-green check
+# for the same reason. An assertion that cannot fail is decoration.
+jq_is(){ # $1=record $2=jq expr $3=want $4=msg
+  local g; g=$(printf '%s' "$1" | jq -r "$2" 2>/dev/null)
+  assert_eq "$g" "$3" "$4"
+}
 
 [ -x "$SLIM" ] || {
   printf '  FAIL - bin/slim-transcript.sh missing or not executable\n'
@@ -36,11 +45,16 @@ trap 'rm -rf "$TMP"' EXIT
 # Run the slimmer over one JSONL record and print the result. head/tail/cap are
 # raised well clear so ONLY the jq pre-pass is under test; the line-based pass is
 # a separate mechanism and would otherwise mask what the pre-pass did.
-slim_one() { # $1=json record -> slimmed record on stdout
+slim_one() { # $1=json record -> slimmed record on stdout, or nothing on failure
   printf '%s\n' "$1" > "$TMP/in.jsonl"
+  # Remove the destination FIRST and check the exit status. Without both, a
+  # failed invocation left the previous case's output sitting at $TMP/out.txt
+  # and the grep below returned THAT — so a broken slimmer would be asserted
+  # against a stale record from an earlier assertion and pass.
+  rm -f "$TMP/out.txt"
   AUTODREAM_SLIM_MAXLINE=100000 AUTODREAM_SLIM_HEAD=9000 AUTODREAM_SLIM_TAIL=9000 \
   AUTODREAM_SLIM_CAP=100000000 \
-    "$SLIM" "$TMP/in.jsonl" "$TMP/out.txt" >/dev/null 2>&1
+    "$SLIM" "$TMP/in.jsonl" "$TMP/out.txt" >/dev/null 2>&1 || return 1
   grep -m1 '^{' "$TMP/out.txt" 2>/dev/null
 }
 
@@ -49,18 +63,26 @@ echo "# slim: a null or absent value is not turned into the string \"null\""
 # a toolResult carrying no content came out asserting the literal text "null" —
 # a value the worker reads as real tool output.
 got=$(slim_one '{"message":{"role":"toolResult","content":null,"toolName":"Read"}}')
-hasnt '"null"' "$got" "a null .content does not become the string \"null\""
+jq_is "$got" '.message.content | type' 'null' "a null .content stays JSON null, not the string \"null\""
 has '"toolName":"Read"' "$got" "and the rest of the record survives"
 
 got=$(slim_one '{"message":{"role":"toolResult","toolName":"Read"}}')
-hasnt '"content"' "$got" "an ABSENT .content is not invented as a key"
+jq_is "$got" '.message | has("content")' 'false' "an ABSENT .content is not invented as a key"
 
 echo "# slim: a small structured value keeps its structure"
 # tostring flattened `arguments` to an escaped JSON string even 40x under the
 # cap, so triage lost the field names it reads. Structure is the payload here.
 got=$(slim_one '{"message":{"content":[{"type":"toolCall","arguments":{"file":"a.txt","n":3}}]}}')
-has '"file":"a.txt"' "$got" "short arguments stay an object, not an escaped string"
-hasnt '\\"file\\"' "$got" "and are not stringified"
+jq_is "$got" '.message.content[0].arguments | type' 'object' \
+  "short arguments stay an OBJECT, not an escaped string"
+jq_is "$got" '.message.content[0].arguments.file' 'a.txt' "and the field names triage reads survive"
+
+# The false branch of the second has() guard. Without a fixture that OMITS
+# arguments, a regression reintroducing a bare `.arguments = (...)` assignment
+# would invent the key and every assertion above would still pass.
+got=$(slim_one '{"message":{"content":[{"type":"toolCall","toolName":"Read"}]}}')
+jq_is "$got" '.message.content[0] | has("arguments")' 'false' \
+  "an ABSENT .arguments is not invented either"
 
 echo "# slim: an oversized value IS truncated"
 # The cap has to still work, or the fix above traded one silent failure for a


### PR DESCRIPTION
Picks up the dual-schema pre-pass that was sitting uncommitted in the working tree, fixes the one line in it that corrupts records, and gives the whole thing the test coverage it never had.

## The pre-pass (not mine, and correct)

OMP stores tool output nowhere near where Claude Code does: whole records keyed `.message.role == "toolResult"`, carrying the payload in `.details` and `.content`, plus a `.providerPayload` blob on assistant turns. Stripping only the Claude shape is worse than stripping neither, because jq exits 0 on the unknown schema. The fallback never fires, the line pass downstream burns its 400-char budget on ~190 chars of OMP envelope, and the worker gets ID soup truncated at `"content":[`. A day of OMP sessions then triages to no findings and looks like a quiet day.

## The bug

`def trunc($n): tostring | ...` ran `tostring` unconditionally. Verified against this exact jq program:

| input | output |
|---|---|
| `{"content":null}` | `{"content":"null"}` |
| `{"role":"toolResult"}` | `{"role":"toolResult","content":"null"}` |
| `{"arguments":{"file":"a.txt","n":3}}` | `{"arguments":"{\"file\":\"a.txt\",\"n\":3}"}` |

Row one hands triage the literal text `"null"` as tool output. Row two invents a key the record never had, so the slimmed transcript asserts something the original never said. Row three flattens a structured object 40x under the cap, destroying the field names that are the only reason the field is kept.

`trunc` now passes null through, truncates strings directly, and serialises a non-string only to measure it, returning the original value when it fits. Both assignments sit behind `has()` guards.

## Coverage

47 lines of schema-sensitive jq across two harnesses had none, in a file whose failure mode is a valid-looking output that quietly says the wrong thing. `tests/slim-transcript.sh` adds 19 assertions covering the three rows above, that an oversized value still is truncated, that `tool_use_id` and `is_error` survive so triage can name a failed call, that `providerPayload` never survives, that an unknown record passes through, and that non-JSONL input still exits 0 with output. Reverting `trunc` to the one-liner fails three.

Wired into `tests/run-all.sh` and the CI matrix rather than left as a file someone remembers to run.

## Also

`.tmp/` is gitignored. 6.7MB of `ai-review-*` panel scratch had accumulated untracked, and since those dirs hold full file dumps, a repo-wide grep for `encode_project` today returned more hits from review transcripts than from the codebase.

Suite 555 passed, 0 failed. shellcheck clean at `--severity=warning` for `bin/*.sh adapters/*/adapter.sh install.sh`, `--severity=error` for `tests/*.sh`.

https://claude.ai/code/session_011s46A6XgpNtU4c42uWnFDC
